### PR TITLE
Recipe collision resolve and more

### DIFF
--- a/src/main/kotlin/com/github/trc/clayium/api/capability/AbstractWorkable.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/capability/AbstractWorkable.kt
@@ -46,6 +46,8 @@ abstract class AbstractWorkable(
      */
     protected abstract fun showRecipesInJei()
 
+    protected open fun getTier(): Int = metaTileEntity.tier.numeric
+
     override fun update() {
         if (metaTileEntity.isRemote || !isWorkingEnabled) return
         if (metaTileEntity.offsetTimer % 20 == 0L) {

--- a/src/main/kotlin/com/github/trc/clayium/api/capability/AbstractWorkable.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/capability/AbstractWorkable.kt
@@ -57,7 +57,9 @@ abstract class AbstractWorkable(
 
         if (isWorking) {
             updateWorkingProgress()
-        } else if (shouldSearchForRecipe()) {
+        }
+        // isWorking can be set to false at [updateWorkingProgress]
+        if (!isWorking && shouldSearchForRecipe()) {
             trySearchNewRecipe()
         }
     }

--- a/src/main/kotlin/com/github/trc/clayium/api/capability/impl/AbstractRecipeLogic.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/capability/impl/AbstractRecipeLogic.kt
@@ -48,10 +48,10 @@ abstract class AbstractRecipeLogic(
 
     override fun trySearchNewRecipe() {
         var currentRecipe: Recipe? = null
-        currentRecipe = if (previousRecipe?.matches(false, inputInventory, tierNum) == true) {
+        currentRecipe = if (previousRecipe?.matches(false, inputInventory, getTier()) == true) {
             previousRecipe
         } else {
-            recipeRegistry.findRecipe(tierNum, inputInventory.toList())
+            recipeRegistry.findRecipe(getTier(), inputInventory.toList())
         }
 
         if (currentRecipe == null) {
@@ -68,7 +68,7 @@ abstract class AbstractRecipeLogic(
             this.outputsFull = true
             return
         }
-        if (!recipe.matches(true, inputInventory, tierNum)) return
+        if (!recipe.matches(true, inputInventory, getTier())) return
         val (cePerTick, duration) = applyOverclock(recipe.cePerTick, recipe.duration, ocHandler.compensatedFactor)
         this.itemOutputs = outputs
         this.recipeCEt = ClayEnergy(cePerTick)

--- a/src/main/kotlin/com/github/trc/clayium/api/capability/impl/MultiblockRecipeLogic.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/capability/impl/MultiblockRecipeLogic.kt
@@ -1,15 +1,19 @@
 package com.github.trc.clayium.api.capability.impl
 
 import com.github.trc.clayium.api.metatileentity.WorkableMetaTileEntity
+import com.github.trc.clayium.api.metatileentity.multiblock.MultiblockLogic
 import com.github.trc.clayium.common.recipe.registry.RecipeRegistry
-import java.util.function.BooleanSupplier
 
 open class MultiblockRecipeLogic(
     metaTileEntity: WorkableMetaTileEntity,
     recipeRegistry: RecipeRegistry<*>,
-    private val structureFormed: BooleanSupplier,
+    private val multiblockLogic: MultiblockLogic,
 ) : RecipeLogicEnergy(metaTileEntity, recipeRegistry, metaTileEntity.clayEnergyHolder) {
+    override fun getTier(): Int {
+        return multiblockLogic.recipeLogicTier
+    }
+
     override fun canProgress(): Boolean {
-        return structureFormed.asBoolean && super.canProgress()
+        return multiblockLogic.structureFormed
     }
 }

--- a/src/main/kotlin/com/github/trc/clayium/api/capability/impl/RecipeLogicClayFurnace.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/capability/impl/RecipeLogicClayFurnace.kt
@@ -47,7 +47,7 @@ class RecipeLogicClayFurnace(
             this.outputsFull = true
             return
         }
-        if (!recipe.matches(true, inputInventory, tierNum)) return
+        if (!recipe.matches(true, inputInventory, getTier())) return
         this.itemOutputs = outputs
         this.recipeCEt = multipliedRecipeCEt
         this.requiredProgress = multipliedRecipeTime

--- a/src/main/kotlin/com/github/trc/clayium/api/capability/impl/RecipeLogicEnergy.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/capability/impl/RecipeLogicEnergy.kt
@@ -26,7 +26,7 @@ open class RecipeLogicEnergy(
      * The speed of these machines depends on the tier.
      */
     fun setDurationMultiplier(provider: (tier: Int) -> Double): RecipeLogicEnergy {
-        durationMultiplier = provider(this.tierNum)
+        durationMultiplier = provider(this.getTier())
         return this
     }
 
@@ -35,7 +35,7 @@ open class RecipeLogicEnergy(
      * The speed of these machines depends on the tier.
      */
     fun setEnergyConsumingMultiplier(provider: (tier: Int) -> Double): RecipeLogicEnergy {
-        energyConsumingMultiplier = provider(this.tierNum)
+        energyConsumingMultiplier = provider(this.getTier())
         return this
     }
 }

--- a/src/main/kotlin/com/github/trc/clayium/api/metatileentity/ClayInterfaceMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/metatileentity/ClayInterfaceMetaTileEntity.kt
@@ -35,8 +35,9 @@ class ClayInterfaceMetaTileEntity(
     override var importItems: IItemHandlerModifiable = EmptyItemStackHandler
     override var exportItems: IItemHandlerModifiable = EmptyItemStackHandler
     override var itemInventory: IItemHandler = EmptyItemStackHandler
-    var autoIoHandler: AutoIoHandler = AutoIoHandler.Combined(this)
+
     private var ecImporter: AutoIoHandler.EcImporter? = null
+    private var autoIoHandler: AutoIoHandler? = null
 
     override var validInputModes: List<MachineIoMode> = onlyNoneList
     override var validOutputModes: List<MachineIoMode> = onlyNoneList
@@ -54,8 +55,8 @@ class ClayInterfaceMetaTileEntity(
         super.onLink(target)
         this.importItems = target.importItems
         this.exportItems = target.exportItems
-        this.itemInventory = ItemHandlerProxy(this.importItems, this.exportItems)
-        this.autoIoHandler = AutoIoHandler.Combined(this)
+        this.itemInventory = ItemHandlerProxy(target.importItems, target.exportItems)
+        this.autoIoHandler = AutoIoHandler.Combined(this, tier = target.tier.numeric)
         target.getCapability(ClayiumTileCapabilities.CLAY_ENERGY_HOLDER, null)?.let { targetEnergyHolder ->
             this.ecImporter = AutoIoHandler.EcImporter(this, targetEnergyHolder.energizedClayItemHandler)
         }
@@ -69,7 +70,7 @@ class ClayInterfaceMetaTileEntity(
         this.importItems = EmptyItemStackHandler
         this.exportItems = EmptyItemStackHandler
         this.itemInventory = EmptyItemStackHandler
-        this.autoIoHandler = AutoIoHandler.Combined(this)
+        this.autoIoHandler = null
         this.ecImporter = null
 
         this.validInputModes = onlyNoneList

--- a/src/main/kotlin/com/github/trc/clayium/api/metatileentity/ClayLaserMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/metatileentity/ClayLaserMetaTileEntity.kt
@@ -27,6 +27,7 @@ import net.minecraftforge.items.IItemHandler
 import net.minecraftforge.items.IItemHandlerModifiable
 import kotlin.math.max
 import kotlin.math.min
+import kotlin.math.pow
 
 class ClayLaserMetaTileEntity(
     metaTileEntityId: ResourceLocation,
@@ -49,7 +50,7 @@ class ClayLaserMetaTileEntity(
     private val clayEnergyHolder = ClayEnergyHolder(this)
     val energyCost = ClayEnergy.milli(
         when (tier.numeric) {
-            in 7..10 -> 400 * Math.pow(10.toDouble(), (tier.numeric - 7).toDouble())
+            in 7..10 -> 400 * 10.toDouble().pow((tier.numeric - 7).toDouble())
             else -> 400
         }.toLong()
     )

--- a/src/main/kotlin/com/github/trc/clayium/api/metatileentity/MTETrait.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/metatileentity/MTETrait.kt
@@ -12,7 +12,6 @@ abstract class MTETrait(
     val name: String,
 ) : ISyncedTileEntity {
 
-    val tierNum = metaTileEntity.tier.numeric
     val networkId = idByName.computeIfAbsent(name) { nextId++ }
 
     init {

--- a/src/main/kotlin/com/github/trc/clayium/api/metatileentity/MetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/metatileentity/MetaTileEntity.kt
@@ -530,7 +530,6 @@ abstract class MetaTileEntity(
     open fun onNeighborChanged(facing: EnumFacing) {
     }
     open fun neighborChanged() {
-        println("NEIGHBOR BLOCK CHANGED")
         EnumFacing.entries.forEach(this::refreshConnection)
         overclockHandler.onNeighborBlockChange()
     }

--- a/src/main/kotlin/com/github/trc/clayium/api/metatileentity/MetaTileEntityHolder.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/metatileentity/MetaTileEntityHolder.kt
@@ -114,6 +114,7 @@ class MetaTileEntityHolder : NeighborCacheTileEntityBase(), ITickable {
         return oldState.block != newSate.block
     }
     override fun shouldRenderInPass(pass: Int) = metaTileEntity?.shouldRenderInPass(pass) ?: super.shouldRenderInPass(pass)
+    @Suppress("UsePropertyAccessSyntax") // `super.maxRenderDistanceSquared` errors with "Unresolved reference"
     override fun getMaxRenderDistanceSquared() = metaTileEntity?.getMaxRenderDistanceSquared() ?: super.getMaxRenderDistanceSquared()
     override fun getRenderBoundingBox() = metaTileEntity?.renderBoundingBox ?: super.getRenderBoundingBox()
 }

--- a/src/main/kotlin/com/github/trc/clayium/api/metatileentity/SyncedTileEntityBase.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/metatileentity/SyncedTileEntityBase.kt
@@ -37,6 +37,7 @@ abstract class SyncedTileEntityBase : TileEntity(), ISyncedTileEntity {
         val backedBuf = Unpooled.buffer()
         writeInitialSyncData(PacketBuffer(backedBuf))
         val updateData = backedBuf.array().copyOf(backedBuf.writerIndex())
+        @Suppress("UsePropertyAccessSyntax") // `super.updateTag` errors with "unresolved reference"
         return super.getUpdateTag().also { it.setByteArray("d", updateData) }
     }
 

--- a/src/main/kotlin/com/github/trc/clayium/api/metatileentity/multiblock/ClayBlastFurnaceMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/metatileentity/multiblock/ClayBlastFurnaceMetaTileEntity.kt
@@ -40,7 +40,7 @@ class ClayBlastFurnaceMetaTileEntity(
     override val exportItems = NotifiableItemStackHandler(this, 2, this, isExport = true)
     override val itemInventory = ItemHandlerProxy(importItems, exportItems)
 
-    override val workable: MultiblockRecipeLogic = MultiblockRecipeLogic(this, recipeRegistry, multiblockLogic::structureFormed)
+    override val workable: MultiblockRecipeLogic = MultiblockRecipeLogic(this, recipeRegistry, multiblockLogic)
 
     private fun checkStructure(handler: MultiblockLogic): StructureValidationResult {
         val world = world

--- a/src/main/kotlin/com/github/trc/clayium/api/metatileentity/multiblock/ClayReactorMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/metatileentity/multiblock/ClayReactorMetaTileEntity.kt
@@ -108,7 +108,7 @@ class ClayReactorMetaTileEntity(
     }
 
     private inner class ClayReactorRecipeLogic : MultiblockRecipeLogic(this@ClayReactorMetaTileEntity,
-        CRecipes.CLAY_REACTOR, multiblockLogic::structureFormed) {
+        CRecipes.CLAY_REACTOR, multiblockLogic) {
         override fun getProgressPerTick(): Long {
             return 1L + (laser?.energy ?: 0.0).toLong()
         }

--- a/src/main/kotlin/com/github/trc/clayium/api/metatileentity/multiblock/LaserProxyMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/metatileentity/multiblock/LaserProxyMetaTileEntity.kt
@@ -68,7 +68,6 @@ class LaserProxyMetaTileEntity(
     }
 
     override fun laserChanged(irradiatedSide: EnumFacing, laser: IClayLaser?) {
-        println("Laser changed: $laser")
         if (irradiatedSide == this.frontFacing) {
             this.laser = laser
             this.target?.getCapability(ClayiumTileCapabilities.CLAY_LASER_ACCEPTOR, this.frontFacing.opposite)

--- a/src/main/kotlin/com/github/trc/clayium/client/renderer/InterfaceRenderer.kt
+++ b/src/main/kotlin/com/github/trc/clayium/client/renderer/InterfaceRenderer.kt
@@ -60,7 +60,8 @@ object InterfaceRenderer {
             GlStateManager.pushMatrix()
                 GlStateManager.translate(0f, 0.275f, 0f)
                 GlStateManager.scale(0.25f, 0.25f, 0.25f)
-                renderString("${targetPos.x}, ${targetPos.y}, ${targetPos.z}; ${targetWorld.provider.dimensionType.getName()}") // .getName() instead of .name for lower-case
+            @Suppress("UsePropertyAccessSyntax") // .getName() instead of .name for lower-case
+            renderString("${targetPos.x}, ${targetPos.y}, ${targetPos.z}; ${targetWorld.provider.dimensionType.getName()}")
             GlStateManager.popMatrix()
         }
         GlStateManager.popMatrix()

--- a/src/main/kotlin/com/github/trc/clayium/common/loaders/recipe/MachineBlockRecipeLoader.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/loaders/recipe/MachineBlockRecipeLoader.kt
@@ -508,13 +508,12 @@ object MachineBlockRecipeLoader {
         val ingotMaterials = listOf(CMaterials.rubidium, CMaterials.lanthanum, CMaterials.caesium, CMaterials.francium,
             CMaterials.radium, CMaterials.tantalum, CMaterials.bismuth, CMaterials.actinium, CMaterials.vanadium)
         for ((i, duplicator) in MetaTileEntities.PAN_DUPLICATOR.slice(1..9).withIndex()) {
-            RecipeUtils.addShapedRecipe("pan_duplicator_rank${i + 1}",
-                duplicator.getStackForm(),
-                "PIP,", "DHD", "PIP",
-                "P", UnificationEntry(OrePrefix.gem, CMaterials.PURE_ANTIMATTERS[i]),
-                "I", UnificationEntry(OrePrefix.ingot, ingotMaterials[i]),
-                "D", MetaTileEntities.PAN_DUPLICATOR[i - 1].getStackForm(),
-                "H", MACHINE_HULL.getItem(ClayTiers.entries[i + 5]))
+            RecipeUtils.addShapedRecipe("pan_duplicator_rank${i + 1}", duplicator.getStackForm(),
+                "PIP", "DHD", "PIP",
+                'P', UnificationEntry(OrePrefix.gem, CMaterials.PURE_ANTIMATTERS[i]),
+                'I', UnificationEntry(OrePrefix.ingot, ingotMaterials[i]),
+                'D', MetaTileEntities.PAN_DUPLICATOR[i].getStackForm(),
+                'H', MACHINE_HULL.getItem(ClayTiers.entries[i + 5]))
         }
     }
 }

--- a/src/main/kotlin/com/github/trc/clayium/common/metatileentities/ClayFabricatorMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/metatileentities/ClayFabricatorMetaTileEntity.kt
@@ -112,7 +112,7 @@ class ClayFabricatorMetaTileEntity(
                 return
             }
             this.itemOutputs = outputs
-            this.requiredProgress = craftTimeLogic(clayProperty.compressionLevel, count)
+            this.requiredProgress = (craftTimeLogic(clayProperty.compressionLevel, count) / overclockHandler.compensatedFactor).toLong()
             this.currentProgress = 1
             if (clayProperty.energy != null) {
                 this.cePerTick = ClayEnergy((clayProperty.energy * count).energy / this.requiredProgress)

--- a/src/main/kotlin/com/github/trc/clayium/common/metatileentities/ClayFabricatorMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/metatileentities/ClayFabricatorMetaTileEntity.kt
@@ -155,7 +155,6 @@ class ClayFabricatorMetaTileEntity(
          * calculation logic is same as original. you can find that on the japanese wiki page: https://clayium.wiki.fc2.com/wiki/%E6%A9%9F%E6%A2%B0
          */
         private fun getCraftTime(compLevel: Int, stackCount: Int, maxCompLevel: Int, compMitigationFactor: Double, countMitigationFactor: Double, eff: Double): Long {
-            println("compLevel: $compLevel, stackCount: $stackCount, maxCompLevel: $maxCompLevel, compMitigationFactor: $compMitigationFactor, countMitigationFactor: $countMitigationFactor, eff: $eff")
             return (64 * 10.0.pow(maxCompLevel) * (stackCount.toDouble() / 64.0).pow(countMitigationFactor) * compMitigationFactor.pow(compLevel - maxCompLevel) * 20.0 / eff).toLong()
         }
 

--- a/src/main/kotlin/com/github/trc/clayium/common/metatileentities/multiblock/CaReactorMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/metatileentities/multiblock/CaReactorMetaTileEntity.kt
@@ -242,7 +242,7 @@ class CaReactorMetaTileEntity(
         }
     }
 
-    private inner class CaReactorRecipeLogic : MultiblockRecipeLogic(this@CaReactorMetaTileEntity, caReactorRegistry, multiblockLogic::structureFormed) {
+    private inner class CaReactorRecipeLogic : MultiblockRecipeLogic(this@CaReactorMetaTileEntity, caReactorRegistry, multiblockLogic) {
         override fun trySearchNewRecipe() {
             val recipe = caReactorRegistry.findRecipeWithRank(avgHullRank, inputInventory.toList())
             if (recipe == null) {
@@ -252,7 +252,7 @@ class CaReactorMetaTileEntity(
             val duration = (recipe.duration / efficiency).toLong()
             val cePerTick = ClayEnergy((recipe.cePerTick.energy * cePerTickMultiplier).toLong())
             val multipliedRecipe = Recipe(recipe.inputs, recipe.outputs, recipe.chancedOutputs,
-                duration, cePerTick, recipe.tierNumeric)
+                duration, cePerTick, recipe.recipeTier)
             prepareRecipe(multipliedRecipe)
         }
     }

--- a/src/main/kotlin/com/github/trc/clayium/common/recipe/Recipe.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/recipe/Recipe.kt
@@ -17,11 +17,11 @@ data class Recipe(
     /**
      * if `machine.tier.numeric < recipe.tier`, then the recipe is not matched
      */
-    val tierNumeric: Int,
+    val recipeTier: Int,
 ) {
-    fun matches(consumeOnMatch: Boolean, inputsIn: IItemHandlerModifiable, tier: Int): Boolean {
+    fun matches(consumeOnMatch: Boolean, inputsIn: IItemHandlerModifiable, machineTier: Int): Boolean {
 
-        if (this.tierNumeric > tier) return false
+        if (this.recipeTier > machineTier) return false
         val (isItemsMatched, amountsToConsume) = matchesItems(inputsIn.toList())
         if (!isItemsMatched) return false
 
@@ -73,6 +73,6 @@ data class Recipe(
     }
 
     override fun toString(): String {
-        return "Recipe(inputs=$inputs, outputs=$outputs, duration=$duration, cePerTick=$cePerTick, tierNumeric=$tierNumeric)"
+        return "Recipe(inputs=$inputs, outputs=$outputs, duration=$duration, cePerTick=$cePerTick, tierNumeric=$recipeTier)"
     }
 }

--- a/src/main/kotlin/com/github/trc/clayium/common/recipe/builder/ClayFabricatorRecipeBuilder.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/recipe/builder/ClayFabricatorRecipeBuilder.kt
@@ -6,6 +6,7 @@ import com.github.trc.clayium.api.unification.material.CMaterial
 import com.github.trc.clayium.api.unification.material.CPropertyKey
 import com.github.trc.clayium.api.unification.ore.OrePrefix
 import com.github.trc.clayium.common.recipe.Recipe
+import kotlin.math.pow
 
 /**
  * Builder for creating a recipe for the (solar) clay fabricator.
@@ -85,9 +86,9 @@ class ClayFabricatorRecipeBuilder : RecipeBuilder<ClayFabricatorRecipeBuilder> {
                 else -> 1
             }
 
-            val n = (Math.pow(10.0, a + 1.0) * (b - 1)) / (Math.pow(b, a)  - 1)
+            val n = (10.0.pow(a + 1.0) * (b - 1)) / (b.pow(a) - 1)
 
-            return (Math.pow(b, inputTier.toDouble()) * (n / multi)).toLong()
+            return (b.pow(inputTier.toDouble()) * (n / multi)).toLong()
         }
     }
 }

--- a/src/main/kotlin/com/github/trc/clayium/common/recipe/builder/ClayFabricatorRecipeBuilder.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/recipe/builder/ClayFabricatorRecipeBuilder.kt
@@ -42,7 +42,7 @@ class ClayFabricatorRecipeBuilder : RecipeBuilder<ClayFabricatorRecipeBuilder> {
             duration = duration,
             cePerTick = cet,
             chancedOutputs = null,
-            tierNumeric = tier
+            recipeTier = tier
         )
 
         recipeRegistry.addRecipe(recipe)

--- a/src/main/kotlin/com/github/trc/clayium/common/recipe/registry/RecipeRegistry.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/recipe/registry/RecipeRegistry.kt
@@ -34,9 +34,9 @@ open class RecipeRegistry<R: RecipeBuilder<R>>(
         builder.buildAndRegister()
     }
 
-    fun findRecipe(tier: Int, inputsIn: List<ItemStack>): Recipe? {
-        return _recipes.find {
-            it.tierNumeric <= tier && it.matches(inputsIn)
+    fun findRecipe(machineTier: Int, inputsIn: List<ItemStack>): Recipe? {
+        return _recipes.find { recipe ->
+            recipe.recipeTier <= machineTier && recipe.matches(inputsIn)
         }
     }
 
@@ -59,7 +59,7 @@ open class RecipeRegistry<R: RecipeBuilder<R>>(
             Clayium.LOGGER.error("invalid recipe: Output has an empty ItemStack.")
             return Result.failure(IllegalArgumentException())
         }
-        if (recipe.tierNumeric < 0) {
+        if (recipe.recipeTier < 0) {
             Clayium.LOGGER.info("invalid recipe: Tier is less than 0.")
             return Result.failure(IllegalArgumentException())
         }

--- a/src/main/kotlin/com/github/trc/clayium/common/recipe/registry/RecipeRegistry.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/recipe/registry/RecipeRegistry.kt
@@ -42,7 +42,10 @@ open class RecipeRegistry<R: RecipeBuilder<R>>(
 
     fun addRecipe(recipe: Recipe) {
         validateRecipe(recipe)
-            .onSuccess { _recipes.add(it) }
+            .onSuccess { recipe ->
+                _recipes.add(recipe)
+                _recipes.sortWith(TIER_DURATION_CE)
+            }
             .onFailure { Clayium.LOGGER.error("Failed to add recipe: $recipe") }
     }
 
@@ -72,5 +75,11 @@ open class RecipeRegistry<R: RecipeBuilder<R>>(
 
     fun getAllRecipes(): List<Recipe> {
         return _recipes.toList()
+    }
+
+    companion object {
+        val TIER_DURATION_CE = Comparator.comparingInt(Recipe::recipeTier)
+            .thenComparingLong(Recipe::duration)
+            .thenComparingLong { recipe -> recipe.cePerTick.energy }
     }
 }

--- a/src/main/kotlin/com/github/trc/clayium/common/recipe/registry/RecipeRegistry.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/recipe/registry/RecipeRegistry.kt
@@ -44,7 +44,7 @@ open class RecipeRegistry<R: RecipeBuilder<R>>(
         validateRecipe(recipe)
             .onSuccess { recipe ->
                 _recipes.add(recipe)
-                _recipes.sortWith(TIER_DURATION_CE)
+                _recipes.sortWith(TIER_DURATION_CE_REVERSED)
             }
             .onFailure { Clayium.LOGGER.error("Failed to add recipe: $recipe") }
     }
@@ -74,12 +74,14 @@ open class RecipeRegistry<R: RecipeBuilder<R>>(
     }
 
     fun getAllRecipes(): List<Recipe> {
-        return _recipes.toList()
+        return _recipes.sortedWith(TIER_DURATION_CE)
     }
 
     companion object {
         val TIER_DURATION_CE = Comparator.comparingInt(Recipe::recipeTier)
             .thenComparingLong(Recipe::duration)
             .thenComparingLong { recipe -> recipe.cePerTick.energy }
+
+        val TIER_DURATION_CE_REVERSED = TIER_DURATION_CE.reversed()
     }
 }

--- a/src/main/kotlin/com/github/trc/clayium/integration/jei/basic/ClayiumRecipeWrapper.kt
+++ b/src/main/kotlin/com/github/trc/clayium/integration/jei/basic/ClayiumRecipeWrapper.kt
@@ -18,7 +18,7 @@ open class ClayiumRecipeWrapper(
     override fun drawInfo(minecraft: Minecraft, recipeWidth: Int, recipeHeight: Int, mouseX: Int, mouseY: Int) {
         val energyConsumed = NumberFormat.formatWithMaxDigits((recipe.cePerTick.energy.toDouble() * recipe.duration) / 100_000, 3)
         val craftTime = NumberFormat.formatWithMaxDigits(recipe.duration.toDouble(), 3)
-        minecraft.fontRenderer.drawString("Tier: ${recipe.tierNumeric}", 6, 43, 0x404040)
+        minecraft.fontRenderer.drawString("Tier: ${recipe.recipeTier}", 6, 43, 0x404040)
         minecraft.fontRenderer.drawString(
             "${recipe.cePerTick.format()}/t x ${craftTime}t = ${energyConsumed}CE",
             6, 52, 0x404040

--- a/src/main/kotlin/com/github/trc/clayium/integration/jei/basic/SolarClayFabricatorRecipeWrapper.kt
+++ b/src/main/kotlin/com/github/trc/clayium/integration/jei/basic/SolarClayFabricatorRecipeWrapper.kt
@@ -9,7 +9,7 @@ class SolarClayFabricatorRecipeWrapper(
 ) : ClayiumRecipeWrapper(recipe) {
     override fun drawInfo(minecraft: Minecraft, recipeWidth: Int, recipeHeight: Int, mouseX: Int, mouseY: Int) {
         // draw "Tier" at center top
-        val tierText = "Tier: ${recipe.tierNumeric}"
+        val tierText = "Tier: ${recipe.recipeTier}"
         val tierTextWidth = minecraft.fontRenderer.getStringWidth(tierText)
         minecraft.fontRenderer.drawString(tierText, (recipeWidth - tierTextWidth) / 2, 3, 0x404040)
 


### PR DESCRIPTION
- fixes #115 
- fixes a bug where the tier of a multiblock is static
- fixes a bug where the compensatedFactor of overclocking is not applied to ClayFabricator
- fixes a bug where the interval of machine IO is 1 tick longer than expected
- fixes a bug where new recipes would not be searched for in the tick that the recipe was completed