### PR TITLE
Fix & Nerf PAN Duplicator

### DIFF
--- a/src/main/kotlin/com/github/trc/clayium/api/capability/impl/AbstractRecipeLogic.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/capability/impl/AbstractRecipeLogic.kt
@@ -4,9 +4,9 @@ import com.github.trc.clayium.api.ClayEnergy
 import com.github.trc.clayium.api.capability.AbstractWorkable
 import com.github.trc.clayium.api.capability.ClayiumTileCapabilities
 import com.github.trc.clayium.api.metatileentity.MetaTileEntity
+import com.github.trc.clayium.api.recipe.IRecipeProvider
 import com.github.trc.clayium.api.util.toList
 import com.github.trc.clayium.common.recipe.Recipe
-import com.github.trc.clayium.common.recipe.registry.RecipeRegistry
 import com.github.trc.clayium.common.util.TransferUtils
 import com.github.trc.clayium.integration.jei.JeiPlugin
 import net.minecraft.nbt.NBTTagCompound
@@ -19,7 +19,7 @@ import kotlin.math.pow
  */
 abstract class AbstractRecipeLogic(
     metaTileEntity: MetaTileEntity,
-    val recipeRegistry: RecipeRegistry<*>,
+    val recipeProvider: IRecipeProvider,
 ) : AbstractWorkable(metaTileEntity) {
 
     protected val inputInventory = metaTileEntity.importItems
@@ -40,7 +40,10 @@ abstract class AbstractRecipeLogic(
     protected abstract fun drawEnergy(ce: ClayEnergy, simulate: Boolean = false): Boolean
 
     override fun showRecipesInJei() {
-        JeiPlugin.jeiRuntime.recipesGui.showCategories(listOf(this.recipeRegistry.category.uniqueId))
+        val categories = recipeProvider.jeiCategories
+        if (categories.isNotEmpty()) {
+            JeiPlugin.jeiRuntime.recipesGui.showCategories(categories)
+        }
     }
 
     final override fun updateWorkingProgress() {
@@ -53,7 +56,7 @@ abstract class AbstractRecipeLogic(
         currentRecipe = if (previousRecipe?.matches(false, inputInventory, getTier()) == true) {
             previousRecipe
         } else {
-            recipeRegistry.findRecipe(getTier(), inputInventory.toList())
+            recipeProvider.searchRecipe(getTier(), inputInventory.toList())
         }
 
         if (currentRecipe == null) {

--- a/src/main/kotlin/com/github/trc/clayium/api/capability/impl/RecipeLogicEnergy.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/capability/impl/RecipeLogicEnergy.kt
@@ -2,11 +2,11 @@ package com.github.trc.clayium.api.capability.impl
 
 import com.github.trc.clayium.api.ClayEnergy
 import com.github.trc.clayium.api.metatileentity.MetaTileEntity
-import com.github.trc.clayium.common.recipe.registry.RecipeRegistry
+import com.github.trc.clayium.api.recipe.IRecipeProvider
 
 open class RecipeLogicEnergy(
     metaTileEntity: MetaTileEntity,
-    recipeRegistry: RecipeRegistry<*>,
+    recipeRegistry: IRecipeProvider,
     private val energyHolder: ClayEnergyHolder,
 ) : AbstractRecipeLogic(metaTileEntity, recipeRegistry) {
     private var durationMultiplier = 1.0

--- a/src/main/kotlin/com/github/trc/clayium/api/recipe/IRecipeProvider.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/recipe/IRecipeProvider.kt
@@ -1,0 +1,16 @@
+package com.github.trc.clayium.api.recipe
+
+import com.github.trc.clayium.common.recipe.Recipe
+import net.minecraft.item.ItemStack
+
+/**
+ * Recipe search logic for [com.github.trc.clayium.api.capability.impl.AbstractRecipeLogic].
+ */
+interface IRecipeProvider {
+    /**
+     * null for disable JEI page for this logic.
+     */
+    val jeiCategory: String?
+
+    fun searchRecipe(machineTier: Int, inputs: List<ItemStack>): Recipe?
+}

--- a/src/main/kotlin/com/github/trc/clayium/api/recipe/IRecipeProvider.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/recipe/IRecipeProvider.kt
@@ -7,6 +7,7 @@ import net.minecraft.item.ItemStack
  * Recipe search logic for [com.github.trc.clayium.api.capability.impl.AbstractRecipeLogic].
  */
 interface IRecipeProvider {
+    val jeiCategories get() = listOfNotNull(jeiCategory)
     /**
      * null for disable JEI page for this logic.
      */

--- a/src/main/kotlin/com/github/trc/clayium/common/metatileentities/PanDuplicatorMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/metatileentities/PanDuplicatorMetaTileEntity.kt
@@ -80,11 +80,6 @@ class PanDuplicatorMetaTileEntity(
 
     private var pan: IPan? = null
 
-    override fun update() {
-        super.update()
-        recipeLogic.update()
-    }
-
     override fun onPlacement() {
         this.setInput(EnumFacing.UP, MachineIoMode.ALL)
         this.setInput(this.frontFacing.opposite, MachineIoMode.CE)

--- a/src/main/kotlin/com/github/trc/clayium/common/metatileentities/PanDuplicatorMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/metatileentities/PanDuplicatorMetaTileEntity.kt
@@ -60,8 +60,7 @@ class PanDuplicatorMetaTileEntity(
     tier: ITier,
     private val duplicatorRank: Int,
     private val machineHullTier: ITier = ClayTiers.entries[duplicatorRank + 3]
-) : MetaTileEntity(metaTileEntityId, tier, validInputModesLists[2], validOutputModesLists[1], "pan_duplicator"), IPanUser
-{
+) : MetaTileEntity(metaTileEntityId, tier, validInputModesLists[2], validOutputModesLists[1], "pan_duplicator"), IPanUser {
 
     override val faceTexture = clayiumId("blocks/pan_duplicator")
 

--- a/src/main/kotlin/com/github/trc/clayium/common/metatileentities/PanDuplicatorMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/metatileentities/PanDuplicatorMetaTileEntity.kt
@@ -52,6 +52,7 @@ import net.minecraftforge.fml.relauncher.Side
 import net.minecraftforge.fml.relauncher.SideOnly
 import net.minecraftforge.items.wrapper.CombinedInvWrapper
 import java.util.function.Function
+import kotlin.math.max
 import kotlin.math.pow
 
 class PanDuplicatorMetaTileEntity(
@@ -67,7 +68,7 @@ class PanDuplicatorMetaTileEntity(
     private val ceConsumption = ClayEnergy(10_000 * 10.0.pow(duplicatorRank - 1).toLong())
 
     private val antimatterSlot = NotifiableItemStackHandler(this, 1, this, isExport = false)
-    private val duplicationTargetSlot = NotifiableItemStackHandler(this, 1, this, isExport = true)
+    private val duplicationTargetSlot = NotifiableItemStackHandler(this, 1, this, isExport = false)
 
     override val importItems = CombinedInvWrapper(antimatterSlot, duplicationTargetSlot)
     override val exportItems = NotifiableItemStackHandler(this, 1, this, isExport = true)
@@ -178,7 +179,7 @@ class PanDuplicatorMetaTileEntity(
             if (targetStack.isEmpty) return null
             val dupTarget = duplicationTargetSlot.getStackInSlot(0).copyWithSize(1)
             val energy = pan?.getDuplicationEntries()[ItemAndMeta(dupTarget)] ?: return null
-            val duration = (energy.energy / ceConsumption.energy).toLong()
+            val duration = max(1, (energy.energy / ceConsumption.energy).toLong())
             return SimpleRecipeBuilder()
                 .inputs(antimatterInput)
                 .notConsumable(dupTarget)

--- a/src/main/kotlin/com/github/trc/clayium/common/metatileentities/PanDuplicatorMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/metatileentities/PanDuplicatorMetaTileEntity.kt
@@ -27,6 +27,7 @@ import com.github.trc.clayium.api.util.ClayTiers
 import com.github.trc.clayium.api.util.ITier
 import com.github.trc.clayium.api.util.MachineIoMode
 import com.github.trc.clayium.api.util.clayiumId
+import com.github.trc.clayium.api.util.copyWithSize
 import com.github.trc.clayium.client.model.ModelTextures
 import com.github.trc.clayium.common.gui.ClayGuiTextures
 import com.github.trc.clayium.common.recipe.Recipe
@@ -175,7 +176,7 @@ class PanDuplicatorMetaTileEntity(
             if (!antimatterInput.testItemStackAndAmount(antimatterSlot.getStackInSlot(0))) return null
             val targetStack = duplicationTargetSlot.getStackInSlot(0)
             if (targetStack.isEmpty) return null
-            val dupTarget = duplicationTargetSlot.getStackInSlot(0)
+            val dupTarget = duplicationTargetSlot.getStackInSlot(0).copyWithSize(1)
             val energy = pan?.getDuplicationEntries()[ItemAndMeta(dupTarget)] ?: return null
             val duration = (energy.energy / ceConsumption.energy).toLong()
             return SimpleRecipeBuilder()

--- a/src/main/kotlin/com/github/trc/clayium/common/metatileentities/PanDuplicatorMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/metatileentities/PanDuplicatorMetaTileEntity.kt
@@ -180,7 +180,7 @@ class PanDuplicatorMetaTileEntity(
             val duration = (energy.energy / ceConsumption.energy).toLong()
             return SimpleRecipeBuilder()
                 .inputs(antimatterInput)
-                .input(dupTarget)
+                .notConsumable(dupTarget)
                 .output(dupTarget)
                 .tier(0).CEt(ceConsumption).duration(duration)
                 .build()

--- a/src/main/kotlin/com/github/trc/clayium/common/pan/factories/CPanRecipeFactory.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/pan/factories/CPanRecipeFactory.kt
@@ -19,15 +19,15 @@ object CPanRecipeFactory : IPanRecipeFactory {
         }
         val recipe = metaTileEntity
             ?.getCapability(ClayiumTileCapabilities.RECIPE_LOGIC, null)
-            ?.recipeRegistry
-            ?.findRecipe(Int.MAX_VALUE, stacks)
+            ?.recipeProvider
+            ?.searchRecipe(Int.MAX_VALUE, stacks)
             ?: return null
 
         return PanRecipe(recipe.inputs, recipe.copyOutputs(), recipe.cePerTick * recipe.duration)
     }
 
     private fun getEntryClayReactor(clayReactor: ClayReactorMetaTileEntity, stacks: List<ItemStack>, laserEnergy: Double, laserCostPerTick: ClayEnergy): IPanRecipe? {
-        val recipe = clayReactor.workable.recipeRegistry.findRecipe(Int.MAX_VALUE, stacks) ?: return null
+        val recipe = clayReactor.workable.recipeProvider.searchRecipe(Int.MAX_VALUE, stacks) ?: return null
 
         val finalizedDuration = recipe.duration.toDouble() / (laserEnergy + 1.0)
         val laserEnergyCost = laserCostPerTick * finalizedDuration

--- a/src/main/kotlin/com/github/trc/clayium/common/recipe/Recipe.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/recipe/Recipe.kt
@@ -53,7 +53,7 @@ data class Recipe(
                 }
                 isMatched = ingredient.testItemStackAndAmount(itemStack)
                 if (!isMatched) continue
-                amountsToConsume[i] = ingredient.amount
+                amountsToConsume[i] = ingredient.consumeAmount
                 break
             }
             // one of the ingredients is not matched

--- a/src/main/kotlin/com/github/trc/clayium/common/recipe/builder/RecipeBuilder.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/recipe/builder/RecipeBuilder.kt
@@ -52,7 +52,7 @@ abstract class RecipeBuilder<R: RecipeBuilder<R>>(
         return this as R
     }
 
-    private fun inputs(vararg inputsIn: CRecipeInput): R {
+    fun inputs(vararg inputsIn: CRecipeInput): R {
         inputsIn.forEach { input ->
             if (input.amount <= 0) {
                 CLog.error("input amount must be greater than 0")
@@ -75,7 +75,7 @@ abstract class RecipeBuilder<R: RecipeBuilder<R>>(
         return inputs(CMultiOreRecipeInput(amount, *entries))
     }
 
-    private fun outputs(vararg stacks: ItemStack): R {
+    fun outputs(vararg stacks: ItemStack): R {
         outputs.addAll(stacks)
         return this as R
     }
@@ -170,6 +170,10 @@ abstract class RecipeBuilder<R: RecipeBuilder<R>>(
     fun CEtMicro(cePerTick: Int) = this.CEt(ClayEnergy.micro(cePerTick.toLong()))
 
     open fun buildAndRegister() {
+        recipeRegistry.addRecipe(build())
+    }
+
+    open fun build(): Recipe {
         setDefaults()
 
         val chancedOutputList = if (chancedOutputLogic != null) {
@@ -178,9 +182,7 @@ abstract class RecipeBuilder<R: RecipeBuilder<R>>(
             null
         }
 
-        val recipe = Recipe(inputs, outputs, chancedOutputList,
-            duration, cePerTick, tier)
-        recipeRegistry.addRecipe(recipe)
+        return Recipe(inputs, outputs, chancedOutputList, duration, cePerTick, tier)
     }
 
     protected fun setDefaults() {

--- a/src/main/kotlin/com/github/trc/clayium/common/recipe/builder/RecipeBuilder.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/recipe/builder/RecipeBuilder.kt
@@ -75,6 +75,14 @@ abstract class RecipeBuilder<R: RecipeBuilder<R>>(
         return inputs(CMultiOreRecipeInput(amount, *entries))
     }
 
+    fun notConsumable(stack: ItemStack) = inputs(CItemRecipeInput(stack, stack.count, isConsumable = false))
+    fun notConsumable(item: Item, amount: Int = 1) = notConsumable(ItemStack(item, amount))
+    fun notConsumable(metaItem: MetaItemClayium.MetaValueItem, amount: Int = 1) = notConsumable(metaItem.getStackForm(amount))
+    fun notConsumable(metaTileEntity: MetaTileEntity, amount: Int = 1) = notConsumable(metaTileEntity.getStackForm(amount))
+    fun notConsumable(block: Block, amount: Int = 1) = notConsumable(ItemStack(block, amount))
+    fun notConsumable(oreDict: String, amount: Int = 1) = inputs(COreRecipeInput(oreDict, amount, isConsumable = false))
+    fun notConsumable(orePrefix: OrePrefix, material: IMaterial, amount: Int = 1) = notConsumable(UnificationEntry(orePrefix, material).toString(), amount)
+
     fun outputs(vararg stacks: ItemStack): R {
         outputs.addAll(stacks)
         return this as R

--- a/src/main/kotlin/com/github/trc/clayium/common/recipe/ingredient/CItemRecipeInput.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/recipe/ingredient/CItemRecipeInput.kt
@@ -9,7 +9,7 @@ class CItemRecipeInput(
     isConsumable: Boolean = true,
 ): CRecipeInput(isConsumable) {
 
-    constructor(stack: ItemStack, amount: Int, isConsumable: Boolean): this(listOf(stack), amount, isConsumable)
+    constructor(stack: ItemStack, amount: Int, isConsumable: Boolean = true): this(listOf(stack), amount, isConsumable)
 
     override fun testItemStackAndAmount(stack: ItemStack): Boolean {
         return stacks.any {

--- a/src/main/kotlin/com/github/trc/clayium/common/recipe/ingredient/CItemRecipeInput.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/recipe/ingredient/CItemRecipeInput.kt
@@ -6,9 +6,10 @@ import net.minecraft.item.ItemStack
 class CItemRecipeInput(
     override val stacks: List<ItemStack>,
     override val amount: Int,
-): CRecipeInput() {
+    isConsumable: Boolean = true,
+): CRecipeInput(isConsumable) {
 
-    constructor(stack: ItemStack, amount: Int): this(listOf(stack), amount)
+    constructor(stack: ItemStack, amount: Int, isConsumable: Boolean): this(listOf(stack), amount, isConsumable)
 
     override fun testItemStackAndAmount(stack: ItemStack): Boolean {
         return stacks.any {

--- a/src/main/kotlin/com/github/trc/clayium/common/recipe/ingredient/COreRecipeInput.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/recipe/ingredient/COreRecipeInput.kt
@@ -11,7 +11,7 @@ class COreRecipeInput(
     val oreId: Int,
     override val amount: Int,
     isConsumable: Boolean = true,
-) : CRecipeInput() {
+) : CRecipeInput(isConsumable) {
 
     constructor(oreDict: String, amount: Int = 1, isConsumable: Boolean = true) : this(OreDictionary.getOreID(oreDict), amount, isConsumable)
     constructor(orePrefix: OrePrefix, material: IMaterial, amount: Int = 1, isConsumable: Boolean = true) : this(UnificationEntry(orePrefix, material).toString(), amount, isConsumable)

--- a/src/main/kotlin/com/github/trc/clayium/common/recipe/ingredient/COreRecipeInput.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/recipe/ingredient/COreRecipeInput.kt
@@ -1,6 +1,6 @@
 package com.github.trc.clayium.common.recipe.ingredient
 
-import com.github.trc.clayium.api.unification.material.CMaterial
+import com.github.trc.clayium.api.unification.material.IMaterial
 import com.github.trc.clayium.api.unification.ore.OrePrefix
 import com.github.trc.clayium.api.unification.stack.ItemAndMeta
 import com.github.trc.clayium.api.unification.stack.UnificationEntry
@@ -10,10 +10,11 @@ import net.minecraftforge.oredict.OreDictionary
 class COreRecipeInput(
     val oreId: Int,
     override val amount: Int,
+    isConsumable: Boolean = true,
 ) : CRecipeInput() {
 
-    constructor(oreDict: String, amount: Int = 1) : this(OreDictionary.getOreID(oreDict), amount)
-    constructor(orePrefix: OrePrefix, material: CMaterial, amount: Int = 1) : this(UnificationEntry(orePrefix, material).toString(), amount)
+    constructor(oreDict: String, amount: Int = 1, isConsumable: Boolean = true) : this(OreDictionary.getOreID(oreDict), amount, isConsumable)
+    constructor(orePrefix: OrePrefix, material: IMaterial, amount: Int = 1, isConsumable: Boolean = true) : this(UnificationEntry(orePrefix, material).toString(), amount, isConsumable)
 
     override val stacks by lazy {
         val oreStacks = OreDictionary.getOres(OreDictionary.getOreName(oreId)).map {

--- a/src/main/kotlin/com/github/trc/clayium/common/recipe/ingredient/CRecipeInput.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/recipe/ingredient/CRecipeInput.kt
@@ -4,10 +4,11 @@ import com.github.trc.clayium.api.unification.stack.ItemAndMeta
 import com.github.trc.clayium.api.util.CLog
 import net.minecraft.item.ItemStack
 
-abstract class CRecipeInput {
+abstract class CRecipeInput(val isConsumable: Boolean = true) {
 
     abstract val stacks: List<ItemStack>
     abstract val amount: Int
+    val consumeAmount: Int = if (isConsumable) amount else 0
 
     abstract fun testItemStackAndAmount(stack: ItemStack): Boolean
     abstract fun testIgnoringAmount(item: ItemAndMeta): Boolean

--- a/src/main/kotlin/com/github/trc/clayium/common/recipe/ingredient/CRecipeInput.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/recipe/ingredient/CRecipeInput.kt
@@ -8,7 +8,8 @@ abstract class CRecipeInput(val isConsumable: Boolean = true) {
 
     abstract val stacks: List<ItemStack>
     abstract val amount: Int
-    val consumeAmount: Int = if (isConsumable) amount else 0
+    // $amount is abstract so it must be lazy
+    val consumeAmount: Int by lazy { if (isConsumable) amount else 0 }
 
     abstract fun testItemStackAndAmount(stack: ItemStack): Boolean
     abstract fun testIgnoringAmount(item: ItemAndMeta): Boolean

--- a/src/main/kotlin/com/github/trc/clayium/common/recipe/registry/RecipeRegistry.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/recipe/registry/RecipeRegistry.kt
@@ -1,6 +1,7 @@
 package com.github.trc.clayium.common.recipe.registry
 
 import com.github.trc.clayium.api.CValues
+import com.github.trc.clayium.api.recipe.IRecipeProvider
 import com.github.trc.clayium.api.util.CLog
 import com.github.trc.clayium.api.util.Mods
 import com.github.trc.clayium.common.recipe.Recipe
@@ -15,12 +16,13 @@ open class RecipeRegistry<R: RecipeBuilder<R>>(
     private val builderSample: R,
     val maxInputs: Int,
     val maxOutputs: Int,
-) {
+) : IRecipeProvider {
 
     constructor(translationKey: String, builderSample: R, maxInputs: Int, maxOutputs: Int) :
             this(RecipeCategory.create(CValues.MOD_ID, translationKey), builderSample, maxInputs, maxOutputs)
 
     val categoryName = category.categoryName
+    override val jeiCategory = category.uniqueId
 
     val grsVirtualizedRegistry: RecipeRegistryGrsAdapter?
         = if (Mods.GroovyScript.isModLoaded) RecipeRegistryGrsAdapter(this) else null
@@ -44,6 +46,10 @@ open class RecipeRegistry<R: RecipeBuilder<R>>(
     //todo use hash table?
     fun findRecipe(machineTier: Int, inputsIn: List<ItemStack>): Recipe? {
         return _recipes.firstOrNull { it.matches(inputsIn, machineTier) }
+    }
+
+    override fun searchRecipe(machineTier: Int, inputs: List<ItemStack>): Recipe? {
+        return findRecipe(machineTier, inputs)
     }
 
     fun addRecipe(recipe: Recipe) {


### PR DESCRIPTION
- fix PAN Duplicator is working even if output is full
- PAN Duplicators now consume CE at their MAX rate when active, regardless of the CE/t in the recipe.