### PR TITLE
fix/inf-loop

### DIFF
--- a/src/main/kotlin/com/github/trc/clayium/api/metatileentity/multiblock/LaserProxyMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/metatileentity/multiblock/LaserProxyMetaTileEntity.kt
@@ -11,6 +11,7 @@ import com.github.trc.clayium.api.metatileentity.MetaTileEntity
 import com.github.trc.clayium.api.util.ITier
 import com.github.trc.clayium.api.util.clayiumId
 import net.minecraft.entity.player.EntityPlayer
+import net.minecraft.init.Blocks
 import net.minecraft.util.EnumFacing
 import net.minecraft.util.EnumHand
 import net.minecraft.util.ResourceLocation
@@ -42,6 +43,7 @@ class LaserProxyMetaTileEntity(
 
     override fun unlink() {
         super.unlink()
+        if (targetPos != null && world!!.isBlockLoaded(targetPos!!) && world!!.getBlockState(targetPos!!).block === Blocks.AIR) return
         this.target?.getCapability(ClayiumTileCapabilities.CLAY_LASER_ACCEPTOR, this.frontFacing.opposite)
             ?.acceptLaser(this.frontFacing.opposite, null)
     }

--- a/src/main/kotlin/com/github/trc/clayium/api/metatileentity/multiblock/LaserProxyMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/metatileentity/multiblock/LaserProxyMetaTileEntity.kt
@@ -11,7 +11,6 @@ import com.github.trc.clayium.api.metatileentity.MetaTileEntity
 import com.github.trc.clayium.api.util.ITier
 import com.github.trc.clayium.api.util.clayiumId
 import net.minecraft.entity.player.EntityPlayer
-import net.minecraft.init.Blocks
 import net.minecraft.util.EnumFacing
 import net.minecraft.util.EnumHand
 import net.minecraft.util.ResourceLocation
@@ -43,7 +42,6 @@ class LaserProxyMetaTileEntity(
 
     override fun unlink() {
         super.unlink()
-        if (targetPos != null && world!!.isBlockLoaded(targetPos!!) && world!!.getBlockState(targetPos!!).block === Blocks.AIR) return
         this.target?.getCapability(ClayiumTileCapabilities.CLAY_LASER_ACCEPTOR, this.frontFacing.opposite)
             ?.acceptLaser(this.frontFacing.opposite, null)
     }

--- a/src/main/kotlin/com/github/trc/clayium/api/metatileentity/multiblock/ProxyMetaTileEntityBase.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/metatileentity/multiblock/ProxyMetaTileEntityBase.kt
@@ -64,7 +64,7 @@ abstract class ProxyMetaTileEntityBase(
         this.targetDimensionId = dimId
         this.targetPos = pos
         val world = DimensionManager.getWorld(dimId) ?: return
-        this.teAccess = TileEntityAccess(world, pos, ::onNewTarget, ::unlinkSelf)
+        this.teAccess = TileEntityAccess(world, pos, ::onNewTarget, ::unlink)
         // don't link here, because the target may not be loaded yet.
         // the link will be established onFirstTick.
     }
@@ -130,7 +130,7 @@ abstract class ProxyMetaTileEntityBase(
         this.targetPos = pos
         this.targetDimensionId = world.provider?.dimension ?: -1
         writeTargetData(target)
-        teAccess = TileEntityAccess(world, pos, ::onNewTarget, ::unlinkSelf)
+        teAccess = TileEntityAccess(world, pos, ::onNewTarget, ::unlink)
         markDirty()
     }
 
@@ -139,10 +139,7 @@ abstract class ProxyMetaTileEntityBase(
         writeTargetRemoved()
         markDirty()
     }
-    fun unlinkSelf() {
-        writeTargetRemoved()
-        markDirty()
-    }
+
     /**
      * called when a player attempts to establish a link using a synchronizer.
      * not called when validating the multiblock structure.

--- a/src/main/kotlin/com/github/trc/clayium/api/metatileentity/multiblock/ProxyMetaTileEntityBase.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/metatileentity/multiblock/ProxyMetaTileEntityBase.kt
@@ -64,7 +64,7 @@ abstract class ProxyMetaTileEntityBase(
         this.targetDimensionId = dimId
         this.targetPos = pos
         val world = DimensionManager.getWorld(dimId) ?: return
-        this.teAccess = TileEntityAccess(world, pos, ::onNewTarget, ::unlink)
+        this.teAccess = TileEntityAccess(world, pos, ::onNewTarget, ::unlinkSelf)
         // don't link here, because the target may not be loaded yet.
         // the link will be established onFirstTick.
     }
@@ -130,7 +130,7 @@ abstract class ProxyMetaTileEntityBase(
         this.targetPos = pos
         this.targetDimensionId = world.provider?.dimension ?: -1
         writeTargetData(target)
-        teAccess = TileEntityAccess(world, pos, ::onNewTarget, ::unlink)
+        teAccess = TileEntityAccess(world, pos, ::onNewTarget, ::unlinkSelf)
         markDirty()
     }
 
@@ -139,7 +139,10 @@ abstract class ProxyMetaTileEntityBase(
         writeTargetRemoved()
         markDirty()
     }
-
+    fun unlinkSelf() {
+        writeTargetRemoved()
+        markDirty()
+    }
     /**
      * called when a player attempts to establish a link using a synchronizer.
      * not called when validating the multiblock structure.

--- a/src/main/kotlin/com/github/trc/clayium/api/util/TileEntityAccess.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/util/TileEntityAccess.kt
@@ -17,8 +17,6 @@ import java.lang.ref.WeakReference
 class TileEntityAccess(
     val world: World,
     val pos: BlockPos,
-    private val onNewTileEntityAppeared: ((TileEntity) -> Unit)? = null,
-    private val onTileEntityInvalidated: (() -> Unit)? = null,
 ) {
 
     constructor(tileEntity: TileEntity) : this(tileEntity.world, tileEntity.pos)
@@ -33,9 +31,6 @@ class TileEntityAccess(
             val tileEntity = world.getTileEntity(pos)
             if (tileEntity != null) {
                 weakRef = WeakReference(tileEntity)
-                onNewTileEntityAppeared?.invoke(tileEntity)
-            } else {
-                onTileEntityInvalidated?.invoke()
             }
             tileEntity
         }


### PR DESCRIPTION
LaserProxy側でunlinkが呼ばれたとき、targetPosにブロックがなければ(ブロックがAIRであれば)target側での切断処理を実行しないように変更。