### PR TITLE
fix: compressed block render layer

### DIFF
--- a/src/main/kotlin/com/github/trc/clayium/api/extensions/ccl/CclExtensions.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/extensions/ccl/CclExtensions.kt
@@ -7,12 +7,12 @@ import codechicken.lib.colour.ColourRGBA
  * @return `[a, r, g, b]`
  */
 fun ColourARGB.packIntArray(): IntArray {
-    return intArrayOf(a.toInt(), r.toInt(), g.toInt(), b.toInt())
+    return intArrayOf(a.toInt() and 0xFF, r.toInt() and 0xFF, g.toInt() and 0xFF, b.toInt() and 0xFF)
 }
 
 /**
  * @return `[r, g, b, a]`
  */
 fun ColourRGBA.packIntArray(): IntArray {
-    return intArrayOf(r.toInt(), g.toInt(), b.toInt(), a.toInt())
+    return intArrayOf(r.toInt() and 0xFF, g.toInt() and 0xFF, b.toInt() and 0xFF, a.toInt() and 0xFF)
 }

--- a/src/main/kotlin/com/github/trc/clayium/api/extensions/ccl/CclExtensions.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/extensions/ccl/CclExtensions.kt
@@ -1,0 +1,18 @@
+package com.github.trc.clayium.api.extensions.ccl
+
+import codechicken.lib.colour.ColourARGB
+import codechicken.lib.colour.ColourRGBA
+
+/**
+ * @return `[a, r, g, b]`
+ */
+fun ColourARGB.packIntArray(): IntArray {
+    return intArrayOf(a.toInt(), r.toInt(), g.toInt(), b.toInt())
+}
+
+/**
+ * @return `[r, g, b, a]`
+ */
+fun ColourRGBA.packIntArray(): IntArray {
+    return intArrayOf(r.toInt(), g.toInt(), b.toInt(), a.toInt())
+}

--- a/src/main/kotlin/com/github/trc/clayium/api/unification/material/CMaterial.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/unification/material/CMaterial.kt
@@ -21,7 +21,7 @@ class CMaterial(
     private val flags: Set<CMaterialFlag> = emptySet(),
 ) : Comparable<CMaterial>, IMaterial {
 
-    override val upperCamelName = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, materialId.path)
+    override val upperCamelName: String = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, materialId.path)
     val translationKey = "${materialId.namespace}.material.${materialId.path}"
 
     override fun compareTo(other: CMaterial): Int {

--- a/src/main/kotlin/com/github/trc/clayium/client/ClientProxy.kt
+++ b/src/main/kotlin/com/github/trc/clayium/client/ClientProxy.kt
@@ -81,7 +81,8 @@ class ClientProxy : CommonProxy() {
             val name = material.upperCamelName
 
             val colors = colorsRaw.map { color ->
-                ColourRGBA(0xFF shl 24 or color)
+                ColourRGBA(color shl 8).apply { a = 255.toByte(); println(this) }
+
             }
 
             val sprite = TextureExtra(clayiumId("blocks/compressed_$name").toString(), compressedBlockTextures, colors)

--- a/src/main/kotlin/com/github/trc/clayium/client/ClientProxy.kt
+++ b/src/main/kotlin/com/github/trc/clayium/client/ClientProxy.kt
@@ -1,5 +1,6 @@
 package com.github.trc.clayium.client
 
+import codechicken.lib.colour.ColourRGBA
 import com.github.trc.clayium.api.metatileentity.MetaTileEntityHolder
 import com.github.trc.clayium.api.unification.material.CMaterial
 import com.github.trc.clayium.api.util.clayiumId
@@ -76,8 +77,12 @@ class ClientProxy : CommonProxy() {
         val compressedBlockTextures = listOf("metalblock_base", "metalblock_dark", "metalblock_light")
         texMap = event.map
         for (material in compressedBlockMaterials) {
-            val colors = material.colors ?: return
+            val colorsRaw = material.colors ?: return
             val name = material.upperCamelName
+
+            val colors = colorsRaw.map { color ->
+                ColourRGBA(0xFF shl 24 or color)
+            }
 
             val sprite = TextureExtra(clayiumId("blocks/compressed_$name").toString(), compressedBlockTextures, colors)
             if (event.map.getTextureExtry(sprite.iconName) == null) {

--- a/src/main/kotlin/com/github/trc/clayium/client/ClientProxy.kt
+++ b/src/main/kotlin/com/github/trc/clayium/client/ClientProxy.kt
@@ -1,6 +1,9 @@
 package com.github.trc.clayium.client
 
 import com.github.trc.clayium.api.metatileentity.MetaTileEntityHolder
+import com.github.trc.clayium.api.unification.material.CMaterial
+import com.github.trc.clayium.api.util.clayiumId
+import com.github.trc.clayium.client.gui.TextureExtra
 import com.github.trc.clayium.client.model.LaserReflectorModelLoader
 import com.github.trc.clayium.client.model.MetaTileEntityModelLoader
 import com.github.trc.clayium.client.renderer.ClayLaserReflectorRenderer
@@ -18,6 +21,7 @@ import net.minecraft.client.renderer.block.model.ModelResourceLocation
 import net.minecraft.item.Item
 import net.minecraftforge.client.event.ColorHandlerEvent
 import net.minecraftforge.client.event.ModelRegistryEvent
+import net.minecraftforge.client.event.TextureStitchEvent
 import net.minecraftforge.client.model.ModelLoader
 import net.minecraftforge.client.model.ModelLoaderRegistry
 import net.minecraftforge.common.MinecraftForge
@@ -32,6 +36,8 @@ import net.minecraftforge.registries.IForgeRegistry
 @Suppress("unused")
 @SideOnly(Side.CLIENT)
 class ClientProxy : CommonProxy() {
+
+    private val compressedBlockMaterials = mutableListOf<CMaterial>()
 
     override fun preInit(event: FMLPreInitializationEvent) {
         super.preInit(event)
@@ -59,6 +65,17 @@ class ClientProxy : CommonProxy() {
         ModelLoader.setCustomModelResourceLocation(item, 0, ModelResourceLocation(item.registryName!!, "inventory"))
     }
 
+    fun onTextureStitchPre(event: TextureStitchEvent.Pre) {
+        val compressedBlockTextures = listOf("metalblock_base", "metalblock_dark", "metalblock_light")
+        for (material in compressedBlockMaterials) {
+            val colors = material.colors ?: return
+            val name = material.upperCamelName
+
+            val sprite = TextureExtra(clayiumId(name).toString(), compressedBlockTextures, colors)
+            event.map.setTextureEntry(sprite)
+        }
+    }
+
     @SubscribeEvent
     fun registerModels(event: ModelRegistryEvent) {
         ClayiumBlocks.registerStateMappers()
@@ -76,5 +93,9 @@ class ClientProxy : CommonProxy() {
     fun registerItemColors(e: ColorHandlerEvent.Item) {
         ClayiumBlocks.registerItemColors(e)
         MetaItemClayium.registerColors(e)
+    }
+
+    override fun registerCompressedBlockSprite(material: CMaterial) {
+        compressedBlockMaterials.add(material)
     }
 }

--- a/src/main/kotlin/com/github/trc/clayium/client/ClientProxy.kt
+++ b/src/main/kotlin/com/github/trc/clayium/client/ClientProxy.kt
@@ -20,8 +20,6 @@ import com.github.trc.clayium.common.metatileentities.MetaTileEntities
 import com.github.trc.clayium.common.util.KeyInput
 import net.minecraft.client.Minecraft
 import net.minecraft.client.renderer.block.model.ModelResourceLocation
-import net.minecraft.client.renderer.texture.TextureAtlasSprite
-import net.minecraft.client.renderer.texture.TextureMap
 import net.minecraft.item.Item
 import net.minecraftforge.client.event.ColorHandlerEvent
 import net.minecraftforge.client.event.ModelRegistryEvent
@@ -42,8 +40,6 @@ import net.minecraftforge.registries.IForgeRegistry
 class ClientProxy : CommonProxy() {
 
     private val compressedBlockMaterials = mutableListOf<CMaterial>()
-    private val sprites = mutableMapOf<String, TextureAtlasSprite>()
-    lateinit var texMap: TextureMap
 
     override fun preInit(event: FMLPreInitializationEvent) {
         super.preInit(event)
@@ -75,7 +71,6 @@ class ClientProxy : CommonProxy() {
     @SubscribeEvent
     fun onTextureStitchPre(event: TextureStitchEvent.Pre) {
         val compressedBlockTextures = listOf("metalblock_base", "metalblock_dark", "metalblock_light")
-        texMap = event.map
         for (material in compressedBlockMaterials) {
             val colorsRaw = material.colors ?: return
             val name = material.upperCamelName
@@ -89,8 +84,8 @@ class ClientProxy : CommonProxy() {
             if (event.map.getTextureExtry(sprite.iconName) == null) {
                 event.map.setTextureEntry(sprite)
             }
-            sprites[name] = sprite
         }
+        compressedBlockMaterials.clear()
     }
 
     @SubscribeEvent
@@ -114,9 +109,5 @@ class ClientProxy : CommonProxy() {
 
     override fun registerCompressedBlockSprite(material: CMaterial) {
         compressedBlockMaterials.add(material)
-    }
-
-    override fun getSprite(name: String): TextureAtlasSprite? {
-        return texMap.getTextureExtry(clayiumId(name).toString())
     }
 }

--- a/src/main/kotlin/com/github/trc/clayium/client/ClientProxy.kt
+++ b/src/main/kotlin/com/github/trc/clayium/client/ClientProxy.kt
@@ -79,8 +79,10 @@ class ClientProxy : CommonProxy() {
             val colors = material.colors ?: return
             val name = material.upperCamelName
 
-            val sprite = TextureExtra(clayiumId(name).toString(), compressedBlockTextures, colors)
-            event.map.setTextureEntry(sprite)
+            val sprite = TextureExtra(clayiumId("blocks/compressed_$name").toString(), compressedBlockTextures, colors)
+            if (event.map.getTextureExtry(sprite.iconName) == null) {
+                event.map.setTextureEntry(sprite)
+            }
             sprites[name] = sprite
         }
     }

--- a/src/main/kotlin/com/github/trc/clayium/client/ClientProxy.kt
+++ b/src/main/kotlin/com/github/trc/clayium/client/ClientProxy.kt
@@ -76,7 +76,7 @@ class ClientProxy : CommonProxy() {
             val name = material.upperCamelName
 
             val colors = colorsRaw.map { color ->
-                ColourRGBA(color shl 8).apply { a = 255.toByte(); println(this) }
+                ColourRGBA(color shl 8).apply { a = 255.toByte() }
 
             }
 

--- a/src/main/kotlin/com/github/trc/clayium/client/gui/TextureExtra.kt
+++ b/src/main/kotlin/com/github/trc/clayium/client/gui/TextureExtra.kt
@@ -1,0 +1,108 @@
+package com.github.trc.clayium.client.gui
+
+import com.github.trc.clayium.api.util.clayiumId
+import net.minecraft.client.Minecraft
+import net.minecraft.client.renderer.texture.TextureAtlasSprite
+import net.minecraft.client.resources.IResource
+import net.minecraft.client.resources.IResourceManager
+import net.minecraft.util.ResourceLocation
+import java.awt.image.BufferedImage
+import java.util.function.Function
+
+private const val BASE_PATH = "textures/blocks"
+
+class TextureExtra(
+    id: String,
+    private val extras: List<String>,
+    private val colors: IntArray?,
+) : TextureAtlasSprite(id) {
+    override fun hasCustomLoader(manager: IResourceManager, location: ResourceLocation): Boolean {
+        return true
+    }
+
+    override fun load(manager: IResourceManager, location: ResourceLocation, textureGetter: Function<ResourceLocation?, TextureAtlasSprite?>): Boolean {
+        val mipmapLevels = Minecraft.getMinecraft().gameSettings.mipmapLevels
+        var bufImage: BufferedImage? = null
+        val baseSprite = textureGetter.apply(createRl(extras[0], 0))!!
+        val width = baseSprite.iconWidth
+        val height = baseSprite.iconHeight
+        val pixels = Array<IntArray?> (mipmapLevels + 1) { null }
+        pixels[0] = IntArray(width * height)
+
+        for ((i, extraTex) in extras.withIndex()) {
+            val rl = createRl(extraTex, 0)
+            val resource: IResource = manager.getResource(rl)
+
+            val image = resource.inputStream.use { stream ->
+                val image: BufferedImage = javax.imageio.ImageIO.read(stream)
+                if (colors != null) {
+                    recolorImage(image, colors[i])
+                } else {
+                    image
+                }
+            }
+
+            bufImage = if (bufImage == null) {
+                image
+            } else {
+                blendImages(bufImage, image)
+            }
+        }
+        pixels[0] = bufImage!!.getRGB(0, 0, width, height, pixels[0], 0, width)
+        this.clearFramesTextureData()
+        this.framesTextureData.add(pixels)
+        return false
+    }
+}
+
+private fun createRl(path: String, mipmapLevel: Int): ResourceLocation {
+    return if (mipmapLevel == 0) {
+        clayiumId("$BASE_PATH/$path.png")
+    } else {
+        clayiumId("$BASE_PATH/mipmaps/$path.$mipmapLevel.png")
+    }
+}
+
+private fun blendImages(image0: BufferedImage, image1: BufferedImage): BufferedImage {
+    val ret = image0
+    for (x in 0 until image0.width) {
+        for (y in 0 until image0.height) {
+            val (r0, g0, b0, a0) = destructRgba(image0.getRGB(x, y))
+            val (r1, g1, b1, a1) = destructRgba(image1.getRGB(x, y))
+
+            val a2 = a0 + a1 - a0 * a1 / 255
+            val r2 =
+                if ((a2 == 0)) r0 else (a0 * (255 - a1) * r0 / (255 * a0 + 255 * a1 - a0 * a1) + a1 * 255 * r1 / (255 * a0 + 255 * a1 - a0 * a1))
+            val g2 =
+                if ((a2 == 0)) g0 else (a0 * (255 - a1) * g0 / (255 * a0 + 255 * a1 - a0 * a1) + a1 * 255 * g1 / (255 * a0 + 255 * a1 - a0 * a1))
+            val b2 =
+                if ((a2 == 0)) b0 else (a0 * (255 - a1) * b0 / (255 * a0 + 255 * a1 - a0 * a1) + a1 * 255 * b1 / (255 * a0 + 255 * a1 - a0 * a1))
+            image0.setRGB(x, y, (r2 shl 16) + (g2 shl 8) + b2 + (a2 shl 24))
+        }
+    }
+    return ret
+}
+
+private fun recolorImage(image0: BufferedImage, color: Int): BufferedImage {
+    val ret = image0
+    for (x in 0 until image0.width) {
+        for (y in 0 until image0.height) {
+            val (r0, g0, b0, a0) = destructRgba(image0.getRGB(x, y))
+            val (r1, g1, b1, a1) = destructRgba(color)
+
+            val a2 = a0 * a1 / 255
+            val r2 = r0 * r1 / 255
+            val g2 = g0 * g1 / 255
+            val b2 = b0 * b1 / 255
+            ret.setRGB(x, y, (r2 shl 16) + (g2 shl 8) + b2 + (a2 shl 24))
+        }
+    }
+    return ret
+}
+
+/**
+ * [R, G, B, A] IntArray
+ */
+private fun destructRgba(color: Int): IntArray {
+    return intArrayOf(color shr 16 and 0xFF, color shr 8 and 0xFF, color and 0xFF, color shr 24 and 0xFF)
+}

--- a/src/main/kotlin/com/github/trc/clayium/client/gui/TextureExtra.kt
+++ b/src/main/kotlin/com/github/trc/clayium/client/gui/TextureExtra.kt
@@ -66,11 +66,6 @@ class TextureExtra(
         bufImage!!.getRGB(0, 0, width, height, pixels[0], 0, width)
         this.clearFramesTextureData()
         this.framesTextureData.add(pixels)
-        println("=== TextureExtra ===")
-//        println(pixels[0]!!.map { Integer.toHexString(it).uppercase() })
-//        println("pixels 0 size: ${pixels[0]!!.size}")
-        // Javadoc says, "Returning false from this function will prevent this icon from being stitched onto the master texture."
-        // but it seems to be inverted? or maybe I'm just misunderstanding it // help wanted
         return false
     }
 }
@@ -98,9 +93,6 @@ private fun blendImages(image0: BufferedImage, image1: BufferedImage): BufferedI
             val b2 =
                 if ((a2 == 0)) b0 else (a0 * (255 - a1) * b0 / (255 * a0 + 255 * a1 - a0 * a1) + a1 * 255 * b1 / (255 * a0 + 255 * a1 - a0 * a1))
             image0.setRGB(x, y, (r2 shl 16) + (g2 shl 8) + b2 + (a2 shl 24))
-            if (r2 != 0 || g2 != 0 || b2 != 0) {
-                println("bruh: r2: $r2, g2: $g2, b2: $b2, a2: $a2")
-            }
         }
     }
     return ret
@@ -112,22 +104,13 @@ private fun recolorImage(image0: BufferedImage, colorRGBA: ColourRGBA): Buffered
         for (y in 0..<image0.height) {
             val (a0, r0, g0, b0) = ColourARGB(image0.getRGB(x, y)).packIntArray()
             val (r1, g1, b1, a1) = colorRGBA.packIntArray()
-            println("color1: ${ColourARGB(a0, r0, g0, b0)} color2: ${ColourRGBA(a1, r1, g1, b1)}")
 
             val a2 = a0 * a1 / 255
             val r2 = r0 * r1 / 255
             val g2 = g0 * g1 / 255
             val b2 = b0 * b1 / 255
-            println("$a0 * $a1 / 255 = $a2")
             ret.setRGB(x, y, (r2 shl 16) + (g2 shl 8) + b2 + (a2 shl 24))
         }
     }
     return ret
-}
-
-/**
- * RGBA to [R, G, B, A] IntArray
- */
-private fun destructRgba(color: Int): IntArray {
-    return intArrayOf(color shr 16 and 0xFF, color shr 8 and 0xFF, color and 0xFF, color shr 24 and 0xFF)
 }

--- a/src/main/kotlin/com/github/trc/clayium/client/gui/TextureExtra.kt
+++ b/src/main/kotlin/com/github/trc/clayium/client/gui/TextureExtra.kt
@@ -66,9 +66,10 @@ class TextureExtra(
         bufImage!!.getRGB(0, 0, width, height, pixels[0], 0, width)
         this.clearFramesTextureData()
         this.framesTextureData.add(pixels)
-        println(pixels[0]!!.map { Integer.toHexString(it).uppercase() })
-        println("pixels 0 size: ${pixels[0]!!.size}")
-        // Javadoc says "Returning false from this function will prevent this icon from being stitched onto the master texture."
+        println("=== TextureExtra ===")
+//        println(pixels[0]!!.map { Integer.toHexString(it).uppercase() })
+//        println("pixels 0 size: ${pixels[0]!!.size}")
+        // Javadoc says, "Returning false from this function will prevent this icon from being stitched onto the master texture."
         // but it seems to be inverted? or maybe I'm just misunderstanding it // help wanted
         return false
     }
@@ -84,8 +85,8 @@ private fun createRl(path: String, mipmapLevel: Int): ResourceLocation {
 
 private fun blendImages(image0: BufferedImage, image1: BufferedImage): BufferedImage {
     val ret = image0
-    for (x in 0 until image0.width) {
-        for (y in 0 until image0.height) {
+    for (x in 0..<image0.width) {
+        for (y in 0..<image0.height) {
             val (a0, r0, g0, b0) = ColourARGB(image0.getRGB(x, y)).packIntArray()
             val (a1, r1, g1, b1) = ColourARGB(image1.getRGB(x, y)).packIntArray()
 
@@ -97,6 +98,9 @@ private fun blendImages(image0: BufferedImage, image1: BufferedImage): BufferedI
             val b2 =
                 if ((a2 == 0)) b0 else (a0 * (255 - a1) * b0 / (255 * a0 + 255 * a1 - a0 * a1) + a1 * 255 * b1 / (255 * a0 + 255 * a1 - a0 * a1))
             image0.setRGB(x, y, (r2 shl 16) + (g2 shl 8) + b2 + (a2 shl 24))
+            if (r2 != 0 || g2 != 0 || b2 != 0) {
+                println("bruh: r2: $r2, g2: $g2, b2: $b2, a2: $a2")
+            }
         }
     }
     return ret
@@ -104,15 +108,17 @@ private fun blendImages(image0: BufferedImage, image1: BufferedImage): BufferedI
 
 private fun recolorImage(image0: BufferedImage, colorRGBA: ColourRGBA): BufferedImage {
     val ret = image0
-    for (x in 0 until image0.width) {
-        for (y in 0 until image0.height) {
+    for (x in 0..<image0.width) {
+        for (y in 0..<image0.height) {
             val (a0, r0, g0, b0) = ColourARGB(image0.getRGB(x, y)).packIntArray()
             val (r1, g1, b1, a1) = colorRGBA.packIntArray()
+            println("color1: ${ColourARGB(a0, r0, g0, b0)} color2: ${ColourRGBA(a1, r1, g1, b1)}")
 
             val a2 = a0 * a1 / 255
             val r2 = r0 * r1 / 255
             val g2 = g0 * g1 / 255
             val b2 = b0 * b1 / 255
+            println("$a0 * $a1 / 255 = $a2")
             ret.setRGB(x, y, (r2 shl 16) + (g2 shl 8) + b2 + (a2 shl 24))
         }
     }

--- a/src/main/kotlin/com/github/trc/clayium/client/gui/TextureExtra.kt
+++ b/src/main/kotlin/com/github/trc/clayium/client/gui/TextureExtra.kt
@@ -1,5 +1,8 @@
 package com.github.trc.clayium.client.gui
 
+import codechicken.lib.colour.ColourARGB
+import codechicken.lib.colour.ColourRGBA
+import com.github.trc.clayium.api.extensions.ccl.*
 import com.github.trc.clayium.api.util.CLog
 import com.github.trc.clayium.api.util.clayiumId
 import net.minecraft.client.Minecraft
@@ -15,11 +18,11 @@ private const val BASE_PATH = "textures/blocks"
 class TextureExtra(
     id: String,
     private val extras: List<String>,
-    private val colors: IntArray?,
+    private val colors: List<ColourRGBA>?,
 ) : TextureAtlasSprite(id) {
 
     override fun getDependencies(): Collection<ResourceLocation?> {
-        return extras.map { clayiumId("blocks/${extras[0]}") }
+        return extras.map { clayiumId("blocks/$it") }
     }
 
     override fun hasCustomLoader(manager: IResourceManager, location: ResourceLocation): Boolean {
@@ -63,7 +66,9 @@ class TextureExtra(
         bufImage!!.getRGB(0, 0, width, height, pixels[0], 0, width)
         this.clearFramesTextureData()
         this.framesTextureData.add(pixels)
-        // javadoc says "Returning false from this function will prevent this icon from being stitched onto the master texture."
+        println(pixels[0]!!.map { Integer.toHexString(it).uppercase() })
+        println("pixels 0 size: ${pixels[0]!!.size}")
+        // Javadoc says "Returning false from this function will prevent this icon from being stitched onto the master texture."
         // but it seems to be inverted? or maybe I'm just misunderstanding it // help wanted
         return false
     }
@@ -81,8 +86,8 @@ private fun blendImages(image0: BufferedImage, image1: BufferedImage): BufferedI
     val ret = image0
     for (x in 0 until image0.width) {
         for (y in 0 until image0.height) {
-            val (r0, g0, b0, a0) = destructRgba(image0.getRGB(x, y))
-            val (r1, g1, b1, a1) = destructRgba(image1.getRGB(x, y))
+            val (a0, r0, g0, b0) = ColourARGB(image0.getRGB(x, y)).packIntArray()
+            val (a1, r1, g1, b1) = ColourARGB(image1.getRGB(x, y)).packIntArray()
 
             val a2 = a0 + a1 - a0 * a1 / 255
             val r2 =
@@ -97,12 +102,12 @@ private fun blendImages(image0: BufferedImage, image1: BufferedImage): BufferedI
     return ret
 }
 
-private fun recolorImage(image0: BufferedImage, color: Int): BufferedImage {
+private fun recolorImage(image0: BufferedImage, colorRGBA: ColourRGBA): BufferedImage {
     val ret = image0
     for (x in 0 until image0.width) {
         for (y in 0 until image0.height) {
-            val (r0, g0, b0, a0) = destructRgba(image0.getRGB(x, y))
-            val (r1, g1, b1, a1) = destructRgba(color)
+            val (a0, r0, g0, b0) = ColourARGB(image0.getRGB(x, y)).packIntArray()
+            val (r1, g1, b1, a1) = colorRGBA.packIntArray()
 
             val a2 = a0 * a1 / 255
             val r2 = r0 * r1 / 255
@@ -115,7 +120,7 @@ private fun recolorImage(image0: BufferedImage, color: Int): BufferedImage {
 }
 
 /**
- * [R, G, B, A] IntArray
+ * RGBA to [R, G, B, A] IntArray
  */
 private fun destructRgba(color: Int): IntArray {
     return intArrayOf(color shr 16 and 0xFF, color shr 8 and 0xFF, color and 0xFF, color shr 24 and 0xFF)

--- a/src/main/kotlin/com/github/trc/clayium/client/gui/TextureExtra.kt
+++ b/src/main/kotlin/com/github/trc/clayium/client/gui/TextureExtra.kt
@@ -61,7 +61,9 @@ class TextureExtra(
         pixels[0] = bufImage!!.getRGB(0, 0, width, height, pixels[0], 0, width)
         this.clearFramesTextureData()
         this.framesTextureData.add(pixels)
-        return true
+        // javadoc says "Returning false from this function will prevent this icon from being stitched onto the master texture."
+        // but it seems to be inverted? or maybe I'm just misunderstanding it // help wanted
+        return false
     }
 }
 

--- a/src/main/kotlin/com/github/trc/clayium/client/gui/TextureExtra.kt
+++ b/src/main/kotlin/com/github/trc/clayium/client/gui/TextureExtra.kt
@@ -51,7 +51,7 @@ class TextureExtra(
         pixels[0] = bufImage!!.getRGB(0, 0, width, height, pixels[0], 0, width)
         this.clearFramesTextureData()
         this.framesTextureData.add(pixels)
-        return false
+        return true
     }
 }
 

--- a/src/main/kotlin/com/github/trc/clayium/client/gui/TextureExtra.kt
+++ b/src/main/kotlin/com/github/trc/clayium/client/gui/TextureExtra.kt
@@ -1,5 +1,6 @@
 package com.github.trc.clayium.client.gui
 
+import com.github.trc.clayium.api.util.CLog
 import com.github.trc.clayium.api.util.clayiumId
 import net.minecraft.client.Minecraft
 import net.minecraft.client.renderer.texture.TextureAtlasSprite
@@ -9,7 +10,7 @@ import net.minecraft.util.ResourceLocation
 import java.awt.image.BufferedImage
 import java.util.function.Function
 
-private const val BASE_PATH = "blocks"
+private const val BASE_PATH = "textures/blocks"
 
 class TextureExtra(
     id: String,
@@ -18,7 +19,7 @@ class TextureExtra(
 ) : TextureAtlasSprite(id) {
 
     override fun getDependencies(): Collection<ResourceLocation?> {
-        return extras.map { createRl(it, 0) }
+        return extras.map { clayiumId("blocks/${extras[0]}") }
     }
 
     override fun hasCustomLoader(manager: IResourceManager, location: ResourceLocation): Boolean {
@@ -28,9 +29,9 @@ class TextureExtra(
     override fun load(manager: IResourceManager, location: ResourceLocation, textureGetter: Function<ResourceLocation, TextureAtlasSprite?>): Boolean {
         val mipmapLevels = Minecraft.getMinecraft().gameSettings.mipmapLevels
         var bufImage: BufferedImage? = null
-        val baseSprite = textureGetter.apply(createRl(extras[0], 0))
+        val baseSprite = textureGetter.apply(clayiumId("blocks/${extras[0]}"))
         if (baseSprite == null) {
-            println("baseSprite is null")
+            CLog.error("MetalBlock: baseSprite is null")
             throw NullPointerException("baseSprite is null")
         }
         val width = baseSprite.iconWidth
@@ -66,7 +67,7 @@ class TextureExtra(
 
 private fun createRl(path: String, mipmapLevel: Int): ResourceLocation {
     return if (mipmapLevel == 0) {
-        clayiumId("$BASE_PATH/$path")
+        clayiumId("$BASE_PATH/$path.png")
     } else {
         clayiumId("$BASE_PATH/mipmaps/$path.$mipmapLevel.png")
     }

--- a/src/main/kotlin/com/github/trc/clayium/client/gui/TextureExtra.kt
+++ b/src/main/kotlin/com/github/trc/clayium/client/gui/TextureExtra.kt
@@ -36,6 +36,8 @@ class TextureExtra(
         }
         val width = baseSprite.iconWidth
         val height = baseSprite.iconHeight
+        iconWidth = width
+        iconHeight = height
         val pixels = Array<IntArray?> (mipmapLevels + 1) { null }
         pixels[0] = IntArray(width * height)
 
@@ -58,7 +60,7 @@ class TextureExtra(
                 blendImages(bufImage, image)
             }
         }
-        pixels[0] = bufImage!!.getRGB(0, 0, width, height, pixels[0], 0, width)
+        bufImage!!.getRGB(0, 0, width, height, pixels[0], 0, width)
         this.clearFramesTextureData()
         this.framesTextureData.add(pixels)
         // javadoc says "Returning false from this function will prevent this icon from being stitched onto the master texture."

--- a/src/main/kotlin/com/github/trc/clayium/client/gui/TextureExtra.kt
+++ b/src/main/kotlin/com/github/trc/clayium/client/gui/TextureExtra.kt
@@ -9,21 +9,30 @@ import net.minecraft.util.ResourceLocation
 import java.awt.image.BufferedImage
 import java.util.function.Function
 
-private const val BASE_PATH = "textures/blocks"
+private const val BASE_PATH = "blocks"
 
 class TextureExtra(
     id: String,
     private val extras: List<String>,
     private val colors: IntArray?,
 ) : TextureAtlasSprite(id) {
+
+    override fun getDependencies(): Collection<ResourceLocation?> {
+        return extras.map { createRl(it, 0) }
+    }
+
     override fun hasCustomLoader(manager: IResourceManager, location: ResourceLocation): Boolean {
         return true
     }
 
-    override fun load(manager: IResourceManager, location: ResourceLocation, textureGetter: Function<ResourceLocation?, TextureAtlasSprite?>): Boolean {
+    override fun load(manager: IResourceManager, location: ResourceLocation, textureGetter: Function<ResourceLocation, TextureAtlasSprite?>): Boolean {
         val mipmapLevels = Minecraft.getMinecraft().gameSettings.mipmapLevels
         var bufImage: BufferedImage? = null
-        val baseSprite = textureGetter.apply(createRl(extras[0], 0))!!
+        val baseSprite = textureGetter.apply(createRl(extras[0], 0))
+        if (baseSprite == null) {
+            println("baseSprite is null")
+            throw NullPointerException("baseSprite is null")
+        }
         val width = baseSprite.iconWidth
         val height = baseSprite.iconHeight
         val pixels = Array<IntArray?> (mipmapLevels + 1) { null }
@@ -57,7 +66,7 @@ class TextureExtra(
 
 private fun createRl(path: String, mipmapLevel: Int): ResourceLocation {
     return if (mipmapLevel == 0) {
-        clayiumId("$BASE_PATH/$path.png")
+        clayiumId("$BASE_PATH/$path")
     } else {
         clayiumId("$BASE_PATH/mipmaps/$path.$mipmapLevel.png")
     }

--- a/src/main/kotlin/com/github/trc/clayium/client/model/MetalBlockModel.kt
+++ b/src/main/kotlin/com/github/trc/clayium/client/model/MetalBlockModel.kt
@@ -32,10 +32,13 @@ class MetalBlockModel : IModel {
             if (state == null || side == null) return emptyList()
             val exState = state as? IExtendedBlockState ?: return emptyList()
             val materialName = exState.getValue(BlockCompressed.MATERIAL_NAME)
-            return cache.getOrPut(materialName) {
+            val quads = mutableListOf<BakedQuad>()
+            val allSideQuads = cache.getOrPut(materialName) {
                 val atlas = texGetter.apply(clayiumId("blocks/compressed_$materialName"))
                 EnumFacing.entries.map { ModelTextures.createQuad(it, atlas) }
             }
+            quads.add(allSideQuads[side.index])
+            return quads
         }
 
         override fun isAmbientOcclusion() = true

--- a/src/main/kotlin/com/github/trc/clayium/client/model/MetalBlockModel.kt
+++ b/src/main/kotlin/com/github/trc/clayium/client/model/MetalBlockModel.kt
@@ -1,7 +1,6 @@
 package com.github.trc.clayium.client.model
 
-import com.github.trc.clayium.client.ClientProxy
-import com.github.trc.clayium.common.ClayiumMod
+import com.github.trc.clayium.api.util.clayiumId
 import com.github.trc.clayium.common.blocks.material.BlockCompressed
 import net.minecraft.block.state.IBlockState
 import net.minecraft.client.renderer.block.model.BakedQuad
@@ -34,9 +33,7 @@ class MetalBlockModel : IModel {
             val exState = state as? IExtendedBlockState ?: return emptyList()
             val materialName = exState.getValue(BlockCompressed.MATERIAL_NAME)
             return cache.getOrPut(materialName) {
-                val atlas = ClayiumMod.proxy.getSprite(materialName)!!
-                println("atlas=$atlas, atlasName=${atlas.iconName}")
-                println("missing: ${(ClayiumMod.proxy as ClientProxy).texMap.missingSprite}")
+                val atlas = texGetter.apply(clayiumId("blocks/compressed_$materialName"))
                 EnumFacing.entries.map { ModelTextures.createQuad(it, atlas) }
             }
         }

--- a/src/main/kotlin/com/github/trc/clayium/client/model/MetalBlockModel.kt
+++ b/src/main/kotlin/com/github/trc/clayium/client/model/MetalBlockModel.kt
@@ -1,0 +1,55 @@
+package com.github.trc.clayium.client.model
+
+import com.github.trc.clayium.client.ClientProxy
+import com.github.trc.clayium.common.ClayiumMod
+import com.github.trc.clayium.common.blocks.material.BlockCompressed
+import net.minecraft.block.state.IBlockState
+import net.minecraft.client.renderer.block.model.BakedQuad
+import net.minecraft.client.renderer.block.model.IBakedModel
+import net.minecraft.client.renderer.block.model.ItemOverrideList
+import net.minecraft.client.renderer.texture.TextureAtlasSprite
+import net.minecraft.client.renderer.vertex.VertexFormat
+import net.minecraft.util.EnumFacing
+import net.minecraft.util.ResourceLocation
+import net.minecraftforge.client.model.IModel
+import net.minecraftforge.client.model.ModelLoader
+import net.minecraftforge.common.model.IModelState
+import net.minecraftforge.common.property.IExtendedBlockState
+import java.util.function.Function
+
+class MetalBlockModel : IModel {
+    override fun bake(state: IModelState, format: VertexFormat, bakedTextureGetter: Function<ResourceLocation, TextureAtlasSprite>): IBakedModel {
+        return MetalBlockBakedModel(bakedTextureGetter)
+    }
+
+    class MetalBlockBakedModel(
+        private val texGetter: Function<ResourceLocation, TextureAtlasSprite>
+    ) : IBakedModel {
+
+        // MaterialName -> BakedQuads
+        private val cache = mutableMapOf<String, List<BakedQuad>>()
+
+        override fun getQuads(state: IBlockState?, side: EnumFacing?, rand: Long): List<BakedQuad> {
+            if (state == null || side == null) return emptyList()
+            val exState = state as? IExtendedBlockState ?: return emptyList()
+            val materialName = exState.getValue(BlockCompressed.MATERIAL_NAME)
+            return cache.getOrPut(materialName) {
+                val atlas = ClayiumMod.proxy.getSprite(materialName)!!
+                println("atlas=$atlas, atlasName=${atlas.iconName}")
+                println("missing: ${(ClayiumMod.proxy as ClientProxy).texMap.missingSprite}")
+                EnumFacing.entries.map { ModelTextures.createQuad(it, atlas) }
+            }
+        }
+
+        override fun isAmbientOcclusion() = true
+        override fun isGui3d() = true
+        override fun isBuiltInRenderer() = false
+        override fun getParticleTexture(): TextureAtlasSprite {
+            return ModelLoader.White.INSTANCE
+        }
+
+        override fun getOverrides(): ItemOverrideList {
+            return ItemOverrideList.NONE
+        }
+    }
+}

--- a/src/main/kotlin/com/github/trc/clayium/client/model/MetalBlockModelLoader.kt
+++ b/src/main/kotlin/com/github/trc/clayium/client/model/MetalBlockModelLoader.kt
@@ -1,6 +1,7 @@
 package com.github.trc.clayium.client.model
 
 import com.github.trc.clayium.api.MOD_ID
+import net.minecraft.client.renderer.block.model.ModelResourceLocation
 import net.minecraft.client.resources.IResourceManager
 import net.minecraft.util.ResourceLocation
 import net.minecraftforge.client.model.ICustomModelLoader
@@ -11,7 +12,11 @@ object MetalBlockModelLoader : ICustomModelLoader {
     }
 
     override fun accepts(modelLocation: ResourceLocation): Boolean {
-        return modelLocation.namespace == MOD_ID && modelLocation.path == "material/compressed_material"
+        if (modelLocation !is ModelResourceLocation) return false
+        return modelLocation.namespace == MOD_ID
+                && modelLocation.path == "material/compressed_material"
+                && modelLocation.variant == "variant=block"
+
     }
 
     override fun loadModel(modelLocation: ResourceLocation): IModel {

--- a/src/main/kotlin/com/github/trc/clayium/client/model/MetalBlockModelLoader.kt
+++ b/src/main/kotlin/com/github/trc/clayium/client/model/MetalBlockModelLoader.kt
@@ -1,0 +1,20 @@
+package com.github.trc.clayium.client.model
+
+import com.github.trc.clayium.api.MOD_ID
+import net.minecraft.client.resources.IResourceManager
+import net.minecraft.util.ResourceLocation
+import net.minecraftforge.client.model.ICustomModelLoader
+import net.minecraftforge.client.model.IModel
+
+object MetalBlockModelLoader : ICustomModelLoader {
+    override fun onResourceManagerReload(resourceManager: IResourceManager) {
+    }
+
+    override fun accepts(modelLocation: ResourceLocation): Boolean {
+        return modelLocation.namespace == MOD_ID && modelLocation.path == "material/compressed_material"
+    }
+
+    override fun loadModel(modelLocation: ResourceLocation): IModel {
+        return MetalBlockModel()
+    }
+}

--- a/src/main/kotlin/com/github/trc/clayium/common/CommonProxy.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/CommonProxy.kt
@@ -11,6 +11,7 @@ import com.github.trc.clayium.api.events.ClayiumMteRegistryEvent
 import com.github.trc.clayium.api.gui.MetaTileEntityGuiFactory
 import com.github.trc.clayium.api.metatileentity.MetaTileEntityHolder
 import com.github.trc.clayium.api.unification.OreDictUnifier
+import com.github.trc.clayium.api.unification.material.CMaterial
 import com.github.trc.clayium.api.unification.material.CMaterials
 import com.github.trc.clayium.api.unification.ore.OrePrefix
 import com.github.trc.clayium.api.util.CUtils
@@ -228,4 +229,7 @@ open class CommonProxy {
 
         GameRegistry.registerTileEntity(ChunkLoaderTileEntity::class.java, clayiumId("chunkLoader"))
     }
+
+    /* Client-Only Methods */
+    open fun registerCompressedBlockSprite(material: CMaterial) {}
 }

--- a/src/main/kotlin/com/github/trc/clayium/common/CommonProxy.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/CommonProxy.kt
@@ -47,6 +47,7 @@ import com.github.trc.clayium.integration.CModIntegration
 import com.github.trc.clayium.integration.gregtech.GTOreDictUnifierAdapter
 import com.github.trc.clayium.network.ClayChunkLoaderCallback
 import net.minecraft.block.Block
+import net.minecraft.client.renderer.texture.TextureAtlasSprite
 import net.minecraft.item.Item
 import net.minecraft.item.ItemBlock
 import net.minecraft.item.crafting.IRecipe
@@ -232,4 +233,5 @@ open class CommonProxy {
 
     /* Client-Only Methods */
     open fun registerCompressedBlockSprite(material: CMaterial) {}
+    open fun getSprite(name: String): TextureAtlasSprite? = null
 }

--- a/src/main/kotlin/com/github/trc/clayium/common/blocks/ClayiumBlocks.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/blocks/ClayiumBlocks.kt
@@ -254,26 +254,21 @@ object ClayiumBlocks {
     @SideOnly(Side.CLIENT)
     fun registerBlockColors(e: ColorHandlerEvent.Block) {
         val blockColors = e.blockColors
-//        for (block in COMPRESSED_BLOCKS) {
-//            blockColors.registerBlockColorHandler({ state, _, _, i ->
-//                block.getCMaterial(state).colors?.get(i) ?: 0
-//            }, block)
-//        }
-//        blockColors.registerBlockColorHandler({ state, _, _, _ ->
-//            COLORED_SILICONE.getEnum(state).colorValue
-//        }, COLORED_SILICONE)
+        blockColors.registerBlockColorHandler({ state, _, _, _ ->
+            COLORED_SILICONE.getEnum(state).colorValue
+        }, COLORED_SILICONE)
     }
 
     @SideOnly(Side.CLIENT)
     fun registerItemColors(e: ColorHandlerEvent.Item) {
         val itemColors = e.itemColors
-//        for (item in COMPRESSED_ITEM_BLOCKS) {
-//            itemColors.registerItemColorHandler({ stack, i ->
-//                item.blockMaterial.getCMaterial(stack.itemDamage).colors?.get(i) ?: 0
-//            }, item)
-//        }
-//        itemColors.registerItemColorHandler({ stack, _ ->
-//            COLORED_SILICONE.getEnum(stack).colorValue
-//        }, COLORED_SILICONE)
+        for (item in COMPRESSED_ITEM_BLOCKS) {
+            itemColors.registerItemColorHandler({ stack, i ->
+                item.blockMaterial.getCMaterial(stack.itemDamage).colors?.get(i) ?: 0
+            }, item)
+        }
+        itemColors.registerItemColorHandler({ stack, _ ->
+            COLORED_SILICONE.getEnum(stack).colorValue
+        }, COLORED_SILICONE)
     }
 }

--- a/src/main/kotlin/com/github/trc/clayium/common/blocks/ClayiumBlocks.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/blocks/ClayiumBlocks.kt
@@ -11,6 +11,7 @@ import com.github.trc.clayium.api.unification.material.CPropertyKey
 import com.github.trc.clayium.api.unification.ore.OrePrefix
 import com.github.trc.clayium.api.util.clayiumId
 import com.github.trc.clayium.api.util.getAsItem
+import com.github.trc.clayium.common.ClayiumMod
 import com.github.trc.clayium.common.blocks.chunkloader.ChunkLoaderBlock
 import com.github.trc.clayium.common.blocks.claycraftingtable.BlockClayCraftingBoard
 import com.github.trc.clayium.common.blocks.claytree.BlockClayLeaves
@@ -196,7 +197,10 @@ object ClayiumBlocks {
         val block = BlockCompressed.create(metaMaterialMap)
         block.registryName = clayiumId("compressed_block_$index")
         COMPRESSED_BLOCKS.add(block)
-        metaMaterialMap.values.forEach { compressedBlocks[it] = block }
+        metaMaterialMap.values.forEach {
+            compressedBlocks[it] = block
+            ClayiumMod.proxy.registerCompressedBlockSprite(it)
+        }
     }
 
     @SideOnly(Side.CLIENT)
@@ -250,26 +254,26 @@ object ClayiumBlocks {
     @SideOnly(Side.CLIENT)
     fun registerBlockColors(e: ColorHandlerEvent.Block) {
         val blockColors = e.blockColors
-        for (block in COMPRESSED_BLOCKS) {
-            blockColors.registerBlockColorHandler({ state, _, _, i ->
-                block.getCMaterial(state).colors?.get(i) ?: 0
-            }, block)
-        }
-        blockColors.registerBlockColorHandler({ state, _, _, _ ->
-            COLORED_SILICONE.getEnum(state).colorValue
-        }, COLORED_SILICONE)
+//        for (block in COMPRESSED_BLOCKS) {
+//            blockColors.registerBlockColorHandler({ state, _, _, i ->
+//                block.getCMaterial(state).colors?.get(i) ?: 0
+//            }, block)
+//        }
+//        blockColors.registerBlockColorHandler({ state, _, _, _ ->
+//            COLORED_SILICONE.getEnum(state).colorValue
+//        }, COLORED_SILICONE)
     }
 
     @SideOnly(Side.CLIENT)
     fun registerItemColors(e: ColorHandlerEvent.Item) {
         val itemColors = e.itemColors
-        for (item in COMPRESSED_ITEM_BLOCKS) {
-            itemColors.registerItemColorHandler({ stack, i ->
-                item.blockMaterial.getCMaterial(stack.itemDamage).colors?.get(i) ?: 0
-            }, item)
-        }
-        itemColors.registerItemColorHandler({ stack, _ ->
-            COLORED_SILICONE.getEnum(stack).colorValue
-        }, COLORED_SILICONE)
+//        for (item in COMPRESSED_ITEM_BLOCKS) {
+//            itemColors.registerItemColorHandler({ stack, i ->
+//                item.blockMaterial.getCMaterial(stack.itemDamage).colors?.get(i) ?: 0
+//            }, item)
+//        }
+//        itemColors.registerItemColorHandler({ stack, _ ->
+//            COLORED_SILICONE.getEnum(stack).colorValue
+//        }, COLORED_SILICONE)
     }
 }

--- a/src/main/kotlin/com/github/trc/clayium/common/blocks/material/BlockCompressed.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/blocks/material/BlockCompressed.kt
@@ -1,6 +1,7 @@
 package com.github.trc.clayium.common.blocks.material
 
 import codechicken.lib.block.property.unlisted.UnlistedStringProperty
+import codechicken.lib.render.particle.CustomParticleHandler
 import com.github.trc.clayium.api.unification.material.CMaterial
 import com.github.trc.clayium.api.util.BlockMaterial
 import com.github.trc.clayium.api.util.clayiumId
@@ -11,16 +12,20 @@ import com.github.trc.clayium.common.creativetab.ClayiumCTabs
 import net.minecraft.block.SoundType
 import net.minecraft.block.state.BlockStateContainer
 import net.minecraft.block.state.IBlockState
+import net.minecraft.client.particle.ParticleManager
 import net.minecraft.client.renderer.block.model.ModelResourceLocation
 import net.minecraft.client.renderer.block.statemap.StateMapperBase
 import net.minecraft.creativetab.CreativeTabs
 import net.minecraft.entity.Entity
+import net.minecraft.entity.EntityLivingBase
 import net.minecraft.item.ItemStack
 import net.minecraft.util.BlockRenderLayer
 import net.minecraft.util.NonNullList
 import net.minecraft.util.math.BlockPos
+import net.minecraft.util.math.RayTraceResult
 import net.minecraft.world.IBlockAccess
 import net.minecraft.world.World
+import net.minecraft.world.WorldServer
 import net.minecraftforge.client.model.ModelLoader
 import net.minecraftforge.common.property.IExtendedBlockState
 import net.minecraftforge.fml.relauncher.Side
@@ -65,6 +70,32 @@ abstract class BlockCompressed(mapping: Map<Int, CMaterial>) : BlockMaterialBase
         val material = getCMaterial(state)
         return (state as IExtendedBlockState).withProperty(MATERIAL_NAME, material.upperCamelName)
     }
+
+    /* BoilerPlate for custom particle handling */
+    @SideOnly(Side.CLIENT)
+    override fun addHitEffects(state: IBlockState, world: World, target: RayTraceResult, manager: ParticleManager): Boolean {
+        CustomParticleHandler.handleHitEffects(state, world, target, manager)
+        return true
+    }
+
+    @SideOnly(Side.CLIENT)
+    override fun addDestroyEffects(world: World, pos: BlockPos, manager: ParticleManager): Boolean {
+        CustomParticleHandler.handleDestroyEffects(world, pos, manager)
+        return true
+    }
+
+    override fun addRunningEffects(state: IBlockState, world: World, pos: BlockPos, entity: Entity): Boolean {
+        if (world.isRemote) {
+            CustomParticleHandler.handleRunningEffects(world, pos, state, entity)
+        }
+        return true
+    }
+
+    override fun addLandingEffects(state: IBlockState, worldObj: WorldServer, blockPosition: BlockPos, iblockstate: IBlockState, entity: EntityLivingBase, numberOfParticles: Int): Boolean {
+        CustomParticleHandler.handleLandingEffects(worldObj, blockPosition, entity, numberOfParticles)
+        return true
+    }
+
 
     companion object {
         val MATERIAL_NAME = UnlistedStringProperty("material")

--- a/src/main/kotlin/com/github/trc/clayium/common/blocks/material/BlockCompressed.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/blocks/material/BlockCompressed.kt
@@ -42,7 +42,7 @@ abstract class BlockCompressed(mapping: Map<Int, CMaterial>) : BlockMaterialBase
     }
 
     @SideOnly(Side.CLIENT)
-    override fun getRenderLayer() = BlockRenderLayer.SOLID
+    override fun getRenderLayer() = BlockRenderLayer.TRANSLUCENT
 
     @SideOnly(Side.CLIENT)
     override fun registerModels() {

--- a/src/main/kotlin/com/github/trc/clayium/common/blocks/material/BlockCompressed.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/blocks/material/BlockCompressed.kt
@@ -42,16 +42,17 @@ abstract class BlockCompressed(mapping: Map<Int, CMaterial>) : BlockMaterialBase
     }
 
     @SideOnly(Side.CLIENT)
-    override fun getRenderLayer() = BlockRenderLayer.TRANSLUCENT
+    override fun getRenderLayer() = BlockRenderLayer.SOLID
 
     @SideOnly(Side.CLIENT)
     override fun registerModels() {
-        val loc = ModelResourceLocation(clayiumId("material/compressed_material"), "variant=basic")
+        val blockLoc = ModelResourceLocation(clayiumId("material/compressed_material"), "variant=block")
+        val itemLoc = ModelResourceLocation(clayiumId("material/compressed_material"), "variant=item")
         ModelLoader.setCustomStateMapper(this,
-            object : StateMapperBase() { override fun getModelResourceLocation(state: IBlockState) = loc }
+            object : StateMapperBase() { override fun getModelResourceLocation(state: IBlockState) = blockLoc }
         )
         for (state in blockState.validStates) {
-            ModelLoader.setCustomModelResourceLocation(this.getAsItem(), this.getMetaFromState(state), loc)
+            ModelLoader.setCustomModelResourceLocation(this.getAsItem(), this.getMetaFromState(state), itemLoc)
         }
     }
 

--- a/src/main/kotlin/com/github/trc/clayium/common/blocks/material/BlockCompressed.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/blocks/material/BlockCompressed.kt
@@ -1,5 +1,6 @@
 package com.github.trc.clayium.common.blocks.material
 
+import codechicken.lib.block.property.unlisted.UnlistedStringProperty
 import com.github.trc.clayium.api.unification.material.CMaterial
 import com.github.trc.clayium.api.util.BlockMaterial
 import com.github.trc.clayium.api.util.clayiumId
@@ -8,6 +9,7 @@ import com.github.trc.clayium.common.blocks.BlockMaterialBase
 import com.github.trc.clayium.common.blocks.properties.CMaterialProperty
 import com.github.trc.clayium.common.creativetab.ClayiumCTabs
 import net.minecraft.block.SoundType
+import net.minecraft.block.state.BlockStateContainer
 import net.minecraft.block.state.IBlockState
 import net.minecraft.client.renderer.block.model.ModelResourceLocation
 import net.minecraft.client.renderer.block.statemap.StateMapperBase
@@ -17,8 +19,10 @@ import net.minecraft.item.ItemStack
 import net.minecraft.util.BlockRenderLayer
 import net.minecraft.util.NonNullList
 import net.minecraft.util.math.BlockPos
+import net.minecraft.world.IBlockAccess
 import net.minecraft.world.World
 import net.minecraftforge.client.model.ModelLoader
+import net.minecraftforge.common.property.IExtendedBlockState
 import net.minecraftforge.fml.relauncher.Side
 import net.minecraftforge.fml.relauncher.SideOnly
 
@@ -28,12 +32,17 @@ abstract class BlockCompressed(mapping: Map<Int, CMaterial>) : BlockMaterialBase
         setCreativeTab(ClayiumCTabs.decorations)
     }
 
+    override fun createBlockState(): BlockStateContainer {
+        return BlockStateContainer.Builder(this)
+            .add(getMaterialProperty()).add(MATERIAL_NAME).build()
+    }
+
     override fun getSubBlocks(itemIn: CreativeTabs, items: NonNullList<ItemStack>) {
         super.getSubBlocks(itemIn, items)
     }
 
     @SideOnly(Side.CLIENT)
-    override fun getRenderLayer() = BlockRenderLayer.TRANSLUCENT
+    override fun getRenderLayer() = BlockRenderLayer.SOLID
 
     @SideOnly(Side.CLIENT)
     override fun registerModels() {
@@ -51,7 +60,13 @@ abstract class BlockCompressed(mapping: Map<Int, CMaterial>) : BlockMaterialBase
         return SoundType.METAL
     }
 
+    override fun getExtendedState(state: IBlockState, world: IBlockAccess, pos: BlockPos): IBlockState {
+        val material = getCMaterial(state)
+        return (state as IExtendedBlockState).withProperty(MATERIAL_NAME, material.upperCamelName)
+    }
+
     companion object {
+        val MATERIAL_NAME = UnlistedStringProperty("material")
         fun create(mapping: Map<Int, CMaterial>): BlockCompressed {
             val materials = mapping.values
             val prop = CMaterialProperty(materials, "material")

--- a/src/main/resources/assets/clayium/blockstates/material/compressed_material.json
+++ b/src/main/resources/assets/clayium/blockstates/material/compressed_material.json
@@ -2,7 +2,7 @@
   "forge_marker": 1,
   "variants": {
     "variant": {
-      "basic": { "model": "clayium:compressed_material" }
+      "item": { "model": "clayium:compressed_material" }
     }
   }
 }


### PR DESCRIPTION
<!-- 
For japanese speakers:
PRのタイトルはChangelogに使われるので、なるべく英語にしてください。
PRの内容は日本語で大丈夫です。
-->
## What
前まで、圧縮素材ブロックはAlpha blendingのためにRenderLayerをTRANSLUCENTにしており、レーザがブロック内部まで貫通するなどの問題があった。このPRはそれを修正する。

## Implementation Details
原作と同じように、独自のTextureAtlasSpriteを実装した。

## Outcome
レーザがブロック内部まで貫通しない。

## Potential Compatibility Issues
None

<!-- This PR template is copied and modified from GTCEu's github repo. -->