### PR TITLE
fix: dedicated server crash

### DIFF
--- a/src/main/kotlin/com/github/trc/clayium/client/ClientProxy.kt
+++ b/src/main/kotlin/com/github/trc/clayium/client/ClientProxy.kt
@@ -2,7 +2,6 @@ package com.github.trc.clayium.client
 
 import codechicken.lib.colour.ColourRGBA
 import com.github.trc.clayium.api.metatileentity.MetaTileEntityHolder
-import com.github.trc.clayium.api.unification.material.CMaterial
 import com.github.trc.clayium.api.util.clayiumId
 import com.github.trc.clayium.client.gui.TextureExtra
 import com.github.trc.clayium.client.model.LaserReflectorModelLoader
@@ -39,8 +38,6 @@ import net.minecraftforge.registries.IForgeRegistry
 @SideOnly(Side.CLIENT)
 class ClientProxy : CommonProxy() {
 
-    private val compressedBlockMaterials = mutableListOf<CMaterial>()
-
     override fun preInit(event: FMLPreInitializationEvent) {
         super.preInit(event)
         MinecraftForge.EVENT_BUS.register(KeyInput)
@@ -71,21 +68,22 @@ class ClientProxy : CommonProxy() {
     @SubscribeEvent
     fun onTextureStitchPre(event: TextureStitchEvent.Pre) {
         val compressedBlockTextures = listOf("metalblock_base", "metalblock_dark", "metalblock_light")
-        for (material in compressedBlockMaterials) {
-            val colorsRaw = material.colors ?: return
-            val name = material.upperCamelName
+        for (block in ClayiumBlocks.COMPRESSED_BLOCKS) {
+            for (material in block.mapping.values) {
+                val colorsRaw = material.colors ?: return
+                val name = material.upperCamelName
 
-            val colors = colorsRaw.map { color ->
-                ColourRGBA(color shl 8).apply { a = 255.toByte() }
+                val colors = colorsRaw.map { color ->
+                    ColourRGBA(color shl 8).apply { a = 255.toByte() }
 
-            }
+                }
 
-            val sprite = TextureExtra(clayiumId("blocks/compressed_$name").toString(), compressedBlockTextures, colors)
-            if (event.map.getTextureExtry(sprite.iconName) == null) {
-                event.map.setTextureEntry(sprite)
+                val sprite = TextureExtra(clayiumId("blocks/compressed_$name").toString(), compressedBlockTextures, colors)
+                if (event.map.getTextureExtry(sprite.iconName) == null) {
+                    event.map.setTextureEntry(sprite)
+                }
             }
         }
-        compressedBlockMaterials.clear()
     }
 
     @SubscribeEvent
@@ -105,9 +103,5 @@ class ClientProxy : CommonProxy() {
     fun registerItemColors(e: ColorHandlerEvent.Item) {
         ClayiumBlocks.registerItemColors(e)
         MetaItemClayium.registerColors(e)
-    }
-
-    override fun registerCompressedBlockSprite(material: CMaterial) {
-        compressedBlockMaterials.add(material)
     }
 }

--- a/src/main/kotlin/com/github/trc/clayium/common/CommonProxy.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/CommonProxy.kt
@@ -11,7 +11,6 @@ import com.github.trc.clayium.api.events.ClayiumMteRegistryEvent
 import com.github.trc.clayium.api.gui.MetaTileEntityGuiFactory
 import com.github.trc.clayium.api.metatileentity.MetaTileEntityHolder
 import com.github.trc.clayium.api.unification.OreDictUnifier
-import com.github.trc.clayium.api.unification.material.CMaterial
 import com.github.trc.clayium.api.unification.material.CMaterials
 import com.github.trc.clayium.api.unification.ore.OrePrefix
 import com.github.trc.clayium.api.util.CUtils
@@ -229,7 +228,4 @@ open class CommonProxy {
 
         GameRegistry.registerTileEntity(ChunkLoaderTileEntity::class.java, clayiumId("chunkLoader"))
     }
-
-    /* Client-Only Methods */
-    open fun registerCompressedBlockSprite(material: CMaterial) {}
 }

--- a/src/main/kotlin/com/github/trc/clayium/common/CommonProxy.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/CommonProxy.kt
@@ -47,7 +47,6 @@ import com.github.trc.clayium.integration.CModIntegration
 import com.github.trc.clayium.integration.gregtech.GTOreDictUnifierAdapter
 import com.github.trc.clayium.network.ClayChunkLoaderCallback
 import net.minecraft.block.Block
-import net.minecraft.client.renderer.texture.TextureAtlasSprite
 import net.minecraft.item.Item
 import net.minecraft.item.ItemBlock
 import net.minecraft.item.crafting.IRecipe
@@ -233,5 +232,4 @@ open class CommonProxy {
 
     /* Client-Only Methods */
     open fun registerCompressedBlockSprite(material: CMaterial) {}
-    open fun getSprite(name: String): TextureAtlasSprite? = null
 }

--- a/src/main/kotlin/com/github/trc/clayium/common/blocks/ClayiumBlocks.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/blocks/ClayiumBlocks.kt
@@ -11,7 +11,6 @@ import com.github.trc.clayium.api.unification.material.CPropertyKey
 import com.github.trc.clayium.api.unification.ore.OrePrefix
 import com.github.trc.clayium.api.util.clayiumId
 import com.github.trc.clayium.api.util.getAsItem
-import com.github.trc.clayium.common.ClayiumMod
 import com.github.trc.clayium.common.blocks.chunkloader.ChunkLoaderBlock
 import com.github.trc.clayium.common.blocks.claycraftingtable.BlockClayCraftingBoard
 import com.github.trc.clayium.common.blocks.claytree.BlockClayLeaves
@@ -197,10 +196,7 @@ object ClayiumBlocks {
         val block = BlockCompressed.create(metaMaterialMap)
         block.registryName = clayiumId("compressed_block_$index")
         COMPRESSED_BLOCKS.add(block)
-        metaMaterialMap.values.forEach {
-            compressedBlocks[it] = block
-            ClayiumMod.proxy.registerCompressedBlockSprite(it)
-        }
+        metaMaterialMap.values.forEach { compressedBlocks[it] = block }
     }
 
     @SideOnly(Side.CLIENT)


### PR DESCRIPTION
<!-- 
For japanese speakers:
PRのタイトルはChangelogに使われるので、なるべく英語にしてください。
PRの内容は日本語で大丈夫です。
-->
## What
Fixes a dedicated server crash (#255) and some minor refactoring.

## Implementation Details
removed a reference to `TextureAtlasSprite` on `CommonProxy`.

## Outcome
Fixes #255 

## Potential Compatibility Issues
None


<!-- This PR template is copied and modified from GTCEu's github repo. -->