### PR TITLE
ci: fix branches: master to branches: main

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,6 +2,7 @@ changelog:
   exclude:
     labels:
       - "ignore changelog"
+      - "type: ci"
 
   categories:
     - title: Added

--- a/.github/workflows/pr_required_labels.yaml
+++ b/.github/workflows/pr_required_labels.yaml
@@ -39,5 +39,5 @@ jobs:
         with:
           mode: minimum
           count: 1
-          labels: 'feature, bug, refactoring, translation, ignore changelog'
+          labels: 'feature, bug, refactoring, translation, type: ci, ignore changelog'
           exit_type: failure

--- a/.github/workflows/update_gradle_cache.yaml
+++ b/.github/workflows/update_gradle_cache.yaml
@@ -7,8 +7,7 @@ name: Update Gradle Cache
 
 on:
   push:
-    branches:
-      - master
+    branches: [main, develop]
     paths: ['gradle/**', '**.gradle', 'gradle.properties', 'gradlew**', 'src/main/resources/*_at.cfg']
   workflow_dispatch:
 


### PR DESCRIPTION
<!-- 
For japanese speakers:
PRのタイトルはChangelogに使われるので、なるべく英語にしてください。
PRの内容は日本語で大丈夫です。
-->
## What
Update Gradle Cache`on`が`branches: master`になっているのを、`branches: [main, develop]`に修正した。さらに、ラベル`type: ci`が付与されているPRがChangelogに載らないよう`release.yml`を修正した。

## Outcome
Update Gradle Cacheがちゃんと走る。


## Potential Compatibility Issues
None.

<!-- This PR template is copied and modified from GTCEu's github repo. -->