### PR TITLE
ci: autostop feature for run_server workflow

### DIFF
--- a/.github/actions/run_server_autostop.sh
+++ b/.github/actions/run_server_autostop.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+stdbuf -oL bash -c "./gradlew runServer" | tee /dev/tty | while read line; do
+  if [ "$(echo $line | grep -c "Done")" -gt 0 ]; then
+    echo "Server has started"
+    pkill -P $$
+    exit 0
+  fi
+done

--- a/.github/workflows/run_server.yaml
+++ b/.github/workflows/run_server.yaml
@@ -30,9 +30,9 @@ jobs:
         run: |
           mkdir -p run/server
           echo "eula=true" > run/server/eula.txt
-          echo "stop" > run/server/stop.txt
           echo "level-type=flat" > run/server/server.properties
-          timeout ${{ env.TIMEOUT }} ./gradlew runServer 2>&1 < run/server/stop.txt | tee -a server.log || true
+          chmod +x ./.github/actions/run_server_autostop.sh
+          timeout ${{ env.TIMEOUT }} ./.github/actions/run_server_autostop.sh
 
       - name: Test no errors reported during the server run
         run: |


### PR DESCRIPTION
<!-- 
For japanese speakers:
PRのタイトルはChangelogに使われるので、なるべく英語にしてください。
PRの内容は日本語で大丈夫です。
-->
## What
run_server workflowで、サーバが立ち上がったら自動で停止するよう修正

<!-- This PR template is copied and modified from GTCEu's github repo. -->