### PR TITLE
Ci run server

### DIFF
--- a/.github/actions/run_server_autostop.sh
+++ b/.github/actions/run_server_autostop.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-stdbuf -oL bash -c "./gradlew runServer" | tee /dev/tty | while read line; do
+stdbuf -oL bash -c "./gradlew runServer" | while read line; do
+  echo $line
   if [ "$(echo $line | grep -c "Done")" -gt 0 ]; then
     echo "Server has started"
     pkill -P $$

--- a/.github/workflows/run_server.yaml
+++ b/.github/workflows/run_server.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      TIMEOUT: 120s
+      TIMEOUT: 600s
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
<!-- 
For japanese speakers:
PRのタイトルはChangelogに使われるので、なるべく英語にしてください。
PRの内容は日本語で大丈夫です。
-->
## What
set timeout to 600s in run_server.
echo instead of `tee /dev/tty` because /dev/tty doesn't exist in github actions.