### PR TITLE
Fix salt extracter uses higher CE

### DIFF
--- a/src/main/kotlin/com/github/trc/clayium/common/metatileentities/SaltExtractorMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/metatileentities/SaltExtractorMetaTileEntity.kt
@@ -37,7 +37,12 @@ class SaltExtractorMetaTileEntity(
     override val generatingItem by lazy { OreDictUnifier.get(OrePrefix.dust, CMaterials.salt) }
 
     private val clayEnergyHolder = ClayEnergyHolder(this)
-    private val energyPerProgress = ClayEnergy.of(30)
+    /*
+    5(Efficiency)*300uCE=1500uCE(energy per tick)
+    energy per item = 100/(water*5(efficiency))*1500uCE = 15mCE (when 2 water)
+    energyPerProgress = 15mCE/100(progressMax)=150uCE
+     */
+    private val energyPerProgress = ClayEnergy.micro(150)
 
     override fun createMetaTileEntity(): MetaTileEntity {
         return SaltExtractorMetaTileEntity(this.metaTileEntityId, this.tier)
@@ -61,6 +66,6 @@ class SaltExtractorMetaTileEntity(
     }
 
     override fun canProgress(): Boolean {
-        return super.canProgress() && this.clayEnergyHolder.drawEnergy(energyPerProgress, simulate = false)
+        return super.canProgress() && this.clayEnergyHolder.drawEnergy(energyPerProgress.times(progressPerTick), simulate = false)
     }
 }


### PR DESCRIPTION
<!-- 
For japanese speakers:
PRのタイトルはChangelogに使われるので、なるべく英語にしてください。
PRの内容は日本語で大丈夫です。
-->
## What
Fixes #278 

## Implementation Details
必要エネルギーの計算方法を150μCE*progressPerTickに変更。
そのため、Tierごとに動作に必要な最低CEが変化しています。
なお、周辺の水の量による効率の変化に関しては未実装であり、
暫定的に2ブロックの水があるとして計算をしています。
<!-- This PR template is copied and modified from GTCEu's github repo. -->