### PR TITLE
Fix OreDictionary Input

### DIFF
--- a/src/main/kotlin/com/github/trc/clayium/common/recipe/ingredient/CItemRecipeInput.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/recipe/ingredient/CItemRecipeInput.kt
@@ -2,6 +2,7 @@ package com.github.trc.clayium.common.recipe.ingredient
 
 import com.github.trc.clayium.api.unification.stack.ItemAndMeta
 import net.minecraft.item.ItemStack
+import net.minecraftforge.oredict.OreDictionary
 
 class CItemRecipeInput(
     override val stacks: List<ItemStack>,
@@ -18,15 +19,14 @@ class CItemRecipeInput(
 
     override fun testItemStackAndAmount(stack: ItemStack): Boolean {
         return stacks.any {
-            ItemStack.areItemsEqual(it, stack)
-                    && (!stack.hasSubtypes || stack.metadata == it.metadata || stack.metadata == 32767)
+            OreDictionary.itemMatches(it, stack, false)
                     && stack.count >= amount
         }
     }
 
     override fun testIgnoringAmount(item: ItemAndMeta): Boolean {
         return stacks.any {
-            item.item == it.item && (item.meta == it.metadata || it.metadata == 32767)
+            OreDictionary.itemMatches(it, item.asStack(), false)
         }
     }
 


### PR DESCRIPTION
<!-- 
For japanese speakers:
PRのタイトルはChangelogに使われるので、なるべく英語にしてください。
PRの内容は日本語で大丈夫です。
-->
## What
鉱石辞書インプットが`OreDictionary.WILDCARD_VALUE`を正しく処理していないのを修正

## Implementation Details
`ItemStack`の判定を独自実装から`OreDictionary.itemMatches`に変更
## Outcome
Fixes #285 

<!-- This PR template is copied and modified from GTCEu's github repo. -->