### PR TITLE
Fix: Crash with Quark

### DIFF
--- a/src/main/kotlin/com/github/trc/clayium/common/blocks/clayworktable/TileClayWorkTable.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/blocks/clayworktable/TileClayWorkTable.kt
@@ -47,16 +47,15 @@ class TileClayWorkTable : TileEntity() {
     }
 
     fun canPushButton(id: Int): Boolean {
-        return canStartCraft(itemHandler.getStackInSlot(0), ClayWorkTableMethod.fromId(id)
-            ?: throw IllegalArgumentException("Invalid button id."))
+        return canStartCraft(itemHandler.getStackInSlot(0), ClayWorkTableMethod.fromId(id) ?: return false)
     }
 
     fun pushButton(clicker: EntityPlayer, id: Int) {
         val input = itemHandler.getStackInSlot(0)
         val method: ClayWorkTableMethod = ClayWorkTableMethod.fromId(id)
-            ?: throw IllegalArgumentException("Invalid button id.")
+            ?: return
         val recipe = CWTRecipes.getClayWorkTableRecipe(input, method)
-            ?: throw NullPointerException("Button pushed without any valid recipe! This should not happen.")
+            ?: throw NullPointerException("Button pushed without any valid recipe! This should not happen. Please report this at the issue tracker.")
         if (currentRecipe !== recipe) {
             currentRecipe = recipe
             requiredProgress = recipe.clicks


### PR DESCRIPTION
<!-- 
For japanese speakers:
PRのタイトルはChangelogに使われるので、なるべく英語にしてください。
PRの内容は日本語で大丈夫です。
-->
## What
他ModがGUIにボタンを追加することにより、粘土作業台を開いたときにクラッシュする問題を修正する。

## Implementation Details
QuarkはサバイバルモードだとインベントリGUIにゴミ箱ボタンを追加する。その`buttonId`が`ClayWorkTableMethod`の範囲外であるため実行時例外を吐いていた。そこで、無効な`buttonId`が渡された際には、実行時例外を投げるのではなく、単に`return`するように修正。

## Outcome
Fixes #273 

<!-- This PR template is copied and modified from GTCEu's github repo. -->