### PR TITLE
Fix PAN Bugs

### DIFF
--- a/src/main/kotlin/com/github/trc/clayium/api/capability/ClayiumTileCapabilities.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/capability/ClayiumTileCapabilities.kt
@@ -1,6 +1,7 @@
 package com.github.trc.clayium.api.capability
 
 import com.github.trc.clayium.api.capability.impl.AbstractRecipeLogic
+import com.github.trc.clayium.api.metatileentity.multiblock.MultiblockLogic
 import com.github.trc.clayium.api.metatileentity.trait.AutoIoHandler
 import com.github.trc.clayium.api.pan.IPanAdapter
 import com.github.trc.clayium.api.pan.IPanCable
@@ -27,6 +28,8 @@ object ClayiumTileCapabilities {
     lateinit var WORKABLE: Capability<AbstractWorkable>
     @CapabilityInject(AbstractRecipeLogic::class)
     lateinit var RECIPE_LOGIC: Capability<AbstractRecipeLogic>
+    @CapabilityInject(MultiblockLogic::class)
+    lateinit var MULTIBLOCK: Capability<MultiblockLogic>
 
     @CapabilityInject(IPanCable::class)
     lateinit var PAN_CABLE: Capability<IPanCable>

--- a/src/main/kotlin/com/github/trc/clayium/api/capability/SimpleCapabilityManager.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/capability/SimpleCapabilityManager.kt
@@ -1,6 +1,7 @@
 package com.github.trc.clayium.api.capability
 
 import com.github.trc.clayium.api.capability.impl.AbstractRecipeLogic
+import com.github.trc.clayium.api.metatileentity.multiblock.MultiblockLogic
 import com.github.trc.clayium.api.metatileentity.trait.AutoIoHandler
 import com.github.trc.clayium.api.pan.IPanAdapter
 import com.github.trc.clayium.api.pan.IPanCable
@@ -31,6 +32,7 @@ object SimpleCapabilityManager {
         registerCapabilityWithNoDefault(IControllable::class.java)
         registerCapabilityWithNoDefault(AbstractWorkable::class.java)
         registerCapabilityWithNoDefault(AbstractRecipeLogic::class.java)
+        registerCapabilityWithNoDefault(MultiblockLogic::class.java)
         registerCapabilityWithNoDefault(IPipeConnectable::class.java)
 
         registerCapabilityWithNoDefault(ISynchronizedInterface::class.java)

--- a/src/main/kotlin/com/github/trc/clayium/api/capability/impl/ClayLaserSourceMteTrait.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/capability/impl/ClayLaserSourceMteTrait.kt
@@ -19,7 +19,7 @@ class ClayLaserSourceMteTrait(
     laserBlue: Int = 0,
 ) : MTETrait(metaTileEntity, ClayiumDataCodecs.LASER_CONTROLLER), IClayLaserSource {
 
-    private val sampleLaser = ClayLaser(red = laserRed, green = laserGreen, blue = laserBlue)
+    val sampleLaser = ClayLaser(red = laserRed, green = laserGreen, blue = laserBlue)
     private val delegate = ClayLaserIrradiator(metaTileEntity)
     override var length = 0
         private set(value) {

--- a/src/main/kotlin/com/github/trc/clayium/api/metatileentity/multiblock/MultiblockLogic.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/metatileentity/multiblock/MultiblockLogic.kt
@@ -6,6 +6,7 @@ import com.cleanroommc.modularui.value.sync.SyncHandlers
 import com.cleanroommc.modularui.widgets.TextWidget
 import com.github.trc.clayium.api.MOD_ID
 import com.github.trc.clayium.api.capability.ClayiumDataCodecs.UPDATE_STRUCTURE_VALIDITY
+import com.github.trc.clayium.api.capability.ClayiumTileCapabilities
 import com.github.trc.clayium.api.metatileentity.MTETrait
 import com.github.trc.clayium.api.metatileentity.MetaTileEntity
 import com.github.trc.clayium.api.util.ITier
@@ -15,8 +16,10 @@ import com.github.trc.clayium.api.util.getMetaTileEntity
 import com.github.trc.clayium.common.blocks.BlockMachineHull
 import net.minecraft.client.resources.I18n
 import net.minecraft.network.PacketBuffer
+import net.minecraft.util.EnumFacing
 import net.minecraft.util.math.BlockPos
 import net.minecraft.world.IBlockAccess
+import net.minecraftforge.common.capabilities.Capability
 import kotlin.math.floor
 import kotlin.math.ln
 import kotlin.math.max
@@ -129,6 +132,13 @@ class MultiblockLogic(
     fun tierTextWidget(syncManager: PanelSyncManager): TextWidget {
         syncManager.syncValue("multiblock_tier", SyncHandlers.intNumber({ recipeLogicTier }, { recipeLogicTier = it }))
         return IKey.dynamic { I18n.format("tooltip.clayium.tier", recipeLogicTier) }.asWidgetResizing()
+    }
+
+    override fun <T> getCapability(capability: Capability<T>, facing: EnumFacing?): T? {
+        if (capability === ClayiumTileCapabilities.MULTIBLOCK) {
+            return ClayiumTileCapabilities.MULTIBLOCK.cast(this)
+        }
+        return super.getCapability(capability, facing)
     }
 
     sealed interface BlockValidationResult {

--- a/src/main/kotlin/com/github/trc/clayium/common/metatileentities/PanAdapterMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/metatileentities/PanAdapterMetaTileEntity.kt
@@ -103,6 +103,13 @@ class PanAdapterMetaTileEntity(
         return PanAdapterMetaTileEntity(metaTileEntityId, tier)
     }
 
+    override fun update() {
+        super.update()
+        if (offsetTimer % 20 == 0L) {
+            refreshEntries()
+        }
+    }
+
     override fun <T> getCapability(capability: Capability<T>, facing: EnumFacing?): T? {
         return when {
             capability === ClayiumTileCapabilities.PAN_CABLE -> capability.cast(IPanCable.INSTANCE)

--- a/src/main/kotlin/com/github/trc/clayium/common/metatileentities/PanAdapterMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/metatileentities/PanAdapterMetaTileEntity.kt
@@ -90,7 +90,7 @@ class PanAdapterMetaTileEntity(
         for (i in 0..<laserInventory.slots) {
             val stack = laserInventory.getStackInSlot(i)
             val laserMte = (CUtils.getMetaTileEntity(stack) as? ClayLaserMetaTileEntity)  ?: continue
-            val laser = laserMte.laserManager.irradiatingLaser ?: continue
+            val laser = laserMte.laserManager.sampleLaser
             val laserCostPerTick = laserMte.energyCost
             laserRgb[0] += (laser.red * stack.count)
             laserRgb[1] += (laser.green * stack.count)

--- a/src/main/kotlin/com/github/trc/clayium/common/metatileentities/PanAdapterMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/metatileentities/PanAdapterMetaTileEntity.kt
@@ -30,10 +30,7 @@ import com.github.trc.clayium.api.metatileentity.MetaTileEntity
 import com.github.trc.clayium.api.pan.IPanAdapter
 import com.github.trc.clayium.api.pan.IPanCable
 import com.github.trc.clayium.api.pan.IPanRecipe
-import com.github.trc.clayium.api.util.CUtils
-import com.github.trc.clayium.api.util.ITier
-import com.github.trc.clayium.api.util.clayiumId
-import com.github.trc.clayium.api.util.toList
+import com.github.trc.clayium.api.util.*
 import com.github.trc.clayium.client.model.ModelTextures
 import com.github.trc.clayium.common.gui.ClayGuiTextures
 import com.google.common.collect.ImmutableSet
@@ -90,6 +87,8 @@ class PanAdapterMetaTileEntity(
         for (i in 0..<laserInventory.slots) {
             val stack = laserInventory.getStackInSlot(i)
             val laserMte = (CUtils.getMetaTileEntity(stack) as? ClayLaserMetaTileEntity)  ?: continue
+            // Using White Laser is meaningless in terms of reducing energy cost
+            if (laserMte.tier == ClayTiers.ANTIMATTER) continue
             val laser = laserMte.laserManager.sampleLaser
             val laserCostPerTick = laserMte.energyCost
             laserRgb[0] += (laser.red * stack.count)

--- a/src/main/kotlin/com/github/trc/clayium/common/metatileentities/PanAdapterMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/metatileentities/PanAdapterMetaTileEntity.kt
@@ -166,6 +166,7 @@ class PanAdapterMetaTileEntity(
         recipeInventories.forEachIndexed { i, h ->
             CUtils.writeItems(h, "panAdapterPattern$i", data)
         }
+        CUtils.writeItems(laserInventory, "laserInventory", data)
     }
 
     override fun readFromNBT(data: NBTTagCompound) {
@@ -173,6 +174,7 @@ class PanAdapterMetaTileEntity(
         recipeInventories.forEachIndexed { i, h ->
             CUtils.readItems(h, "panAdapterPattern$i", data)
         }
+        CUtils.readItems(laserInventory, "laserInventory", data)
     }
 
     override fun onFirstTick() {

--- a/src/main/kotlin/com/github/trc/clayium/common/metatileentities/PanCoreMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/metatileentities/PanCoreMetaTileEntity.kt
@@ -111,11 +111,20 @@ class PanCoreMetaTileEntity(
         }
     }
 
-    // TODO: レシピ出力個数を考慮してコストを算出する
+    // TODO: 機械の稼働コストを考慮する
     private fun refreshDuplicationEntries() {
         duplicationEntries.clear()
         duplicationEntries.putAll(defaultDuplicationEntries)
 
+        // --- Algorithm ---
+        // 1. Gather all PanRecipes from PanAdapters.
+        // 2. Traverse entries from defaultDuplicationEntries. Create queue.
+        // 2-1. If all ingredients of a recipe are verified (already duplicatable), add the result to the queue.
+        // 2-2. Calculate the cost etc.
+        // 2-3. repeat while the queue is not empty.
+        // 3. done.
+
+        // -- PART 1: Gather all PanRecipes from PanAdapters --
         // [PanRecipeInternal] has [PanIngredient]s.
         // PanIngredient has a flag that indicates whether the ingredient is duplicatable or not.
         val internalRecipes = panRecipes.map { PanRecipeInternal(it) }
@@ -141,6 +150,7 @@ class PanCoreMetaTileEntity(
             }
         }
 
+        // -- PART 2, 3 --
         val duplicatablesQueue = ArrayDeque<ItemAndMeta>()
         val walked = mutableSetOf<ItemAndMeta>()
         duplicatablesQueue.addAll(defaultDuplicationEntries.keys)
@@ -154,23 +164,23 @@ class PanCoreMetaTileEntity(
             val childRecipes = result2Dependants[parent] ?: continue
             for (childRecipe in childRecipes) {
                 var allVerified = true
-                var totalCost = ClayEnergy.ZERO
+                var totalCostOfChildren = ClayEnergy.ZERO
                 for (ing in childRecipe.ingsWithFlag) {
                     val ingIsChild = ing.ingredient.testIgnoringAmount(parent)
                     if (ingIsChild) {
                         ing.verified = true
-                        val costByThis = duplicationEntries[parent]!!.ce
-                        val currentCostOfIng = ing.cost
-                        val newCost = ClayEnergy(min(costByThis.energy, currentCostOfIng.energy))
-                        totalCost += newCost
+                        val costThisTime = duplicationEntries[parent]!!.ce
+                        val currentCostOfIngredient = ing.cost
+                        val newCost = ClayEnergy(min(costThisTime.energy, currentCostOfIngredient.energy))
+                        totalCostOfChildren += newCost
                     }
                     allVerified = allVerified && ing.verified
                 }
                 if (allVerified) {
                     val panRecipe = childRecipe.panRecipe
-                    for (result in panRecipe.results.map(::ItemAndMeta)) {
+                    for ((result, count) in panRecipe.results.map { Pair(ItemAndMeta(it), it.count) }) {
                         duplicatablesQueue.add(result)
-                        val cost = (totalCost / panRecipe.results.sumOf { it.count }) + panRecipe.requiredClayEnergy
+                        val cost = (totalCostOfChildren + panRecipe.requiredClayEnergy) / count
                         duplicationEntries[result] = PanDuplicationEntry(cost)
                     }
                 }

--- a/src/main/kotlin/com/github/trc/clayium/common/metatileentities/PanCoreMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/metatileentities/PanCoreMetaTileEntity.kt
@@ -26,7 +26,6 @@ import com.github.trc.clayium.api.unification.ore.OrePrefix
 import com.github.trc.clayium.api.unification.stack.ItemAndMeta
 import com.github.trc.clayium.api.unification.stack.readItemAndMeta
 import com.github.trc.clayium.api.unification.stack.writeItemAndMeta
-import com.github.trc.clayium.api.util.CLog
 import com.github.trc.clayium.api.util.ITier
 import com.github.trc.clayium.api.util.clayiumId
 import com.github.trc.clayium.client.model.ModelTextures
@@ -156,10 +155,7 @@ class PanCoreMetaTileEntity(
         duplicatablesQueue.addAll(defaultDuplicationEntries.keys)
         while (duplicatablesQueue.isNotEmpty()) {
             val parent: ItemAndMeta = duplicatablesQueue.removeFirst()
-            if (parent in walked) {
-                CLog.warn("Tried to walk a node that has already been walked: $parent")
-                continue
-            }
+            if (parent in walked) continue
             walked.add(parent)
             val childRecipes = result2Dependants[parent] ?: continue
             for (childRecipe in childRecipes) {

--- a/src/main/kotlin/com/github/trc/clayium/common/metatileentities/PanCoreMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/metatileentities/PanCoreMetaTileEntity.kt
@@ -111,6 +111,7 @@ class PanCoreMetaTileEntity(
         }
     }
 
+    // TODO: レシピ出力個数を考慮してコストを算出する
     private fun refreshDuplicationEntries() {
         duplicationEntries.clear()
         duplicationEntries.putAll(defaultDuplicationEntries)

--- a/src/main/kotlin/com/github/trc/clayium/common/pan/factories/CPanRecipeFactory.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/pan/factories/CPanRecipeFactory.kt
@@ -10,6 +10,7 @@ import com.github.trc.clayium.common.pan.PanRecipe
 import net.minecraft.item.ItemStack
 import net.minecraft.util.math.BlockPos
 import net.minecraft.world.IBlockAccess
+import kotlin.math.ceil
 
 object CPanRecipeFactory : IPanRecipeFactory {
     override fun getEntry(world: IBlockAccess, pos: BlockPos, stacks: List<ItemStack>, laserEnergy: Double, laserCostPerTick: ClayEnergy): IPanRecipe? {
@@ -37,8 +38,7 @@ object CPanRecipeFactory : IPanRecipeFactory {
     private fun getEntryClayReactor(clayReactor: ClayReactorMetaTileEntity, stacks: List<ItemStack>, laserEnergy: Double, laserCostPerTick: ClayEnergy): IPanRecipe? {
         val recipe = clayReactor.workable.recipeProvider.searchRecipe(Int.MAX_VALUE, stacks) ?: return null
 
-        val finalizedDuration = recipe.duration.toDouble() / (laserEnergy + 1.0)
-        val laserEnergyCost = laserCostPerTick * finalizedDuration
-        return PanRecipe(recipe.inputs, recipe.copyOutputs(), recipe.cePerTick * finalizedDuration + laserEnergyCost)
+        val finalizedDuration = ceil(recipe.duration.toDouble() / (laserEnergy + 1.0)).toLong()
+        return PanRecipe(recipe.inputs, recipe.copyOutputs(), (recipe.cePerTick + laserCostPerTick) * finalizedDuration)
     }
 }

--- a/src/main/kotlin/com/github/trc/clayium/common/pan/factories/CPanRecipeFactory.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/pan/factories/CPanRecipeFactory.kt
@@ -20,7 +20,7 @@ object CPanRecipeFactory : IPanRecipeFactory {
         val recipe = metaTileEntity
             ?.getCapability(ClayiumTileCapabilities.RECIPE_LOGIC, null)
             ?.recipeProvider
-            ?.searchRecipe(Int.MAX_VALUE, stacks)
+            ?.searchRecipe(metaTileEntity.tier.numeric, stacks)
             ?: return null
 
         return PanRecipe(recipe.inputs, recipe.copyOutputs(), recipe.cePerTick * recipe.duration)

--- a/src/main/kotlin/com/github/trc/clayium/common/pan/factories/CPanRecipeFactory.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/pan/factories/CPanRecipeFactory.kt
@@ -20,10 +20,8 @@ object CPanRecipeFactory : IPanRecipeFactory {
         var machineTier = metaTileEntity.tier.numeric
 
         if (multiblockCapability != null) {
-            if (metaTileEntity is ClayReactorMetaTileEntity) return getEntryClayReactor(metaTileEntity, stacks, laserEnergy, laserCostPerTick)
-            val multiblockCapability = metaTileEntity.getCapability(ClayiumTileCapabilities.MULTIBLOCK, null)
-                ?: return null
             if (!multiblockCapability.structureFormed) return null
+            if (metaTileEntity is ClayReactorMetaTileEntity) return getEntryClayReactor(metaTileEntity, stacks, laserEnergy, laserCostPerTick)
             machineTier = multiblockCapability.recipeLogicTier
         }
         val recipe = metaTileEntity

--- a/src/main/kotlin/com/github/trc/clayium/common/pan/factories/CPanRecipeFactory.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/pan/factories/CPanRecipeFactory.kt
@@ -38,6 +38,7 @@ object CPanRecipeFactory : IPanRecipeFactory {
     private fun getEntryClayReactor(clayReactor: ClayReactorMetaTileEntity, stacks: List<ItemStack>, laserEnergy: Double, laserCostPerTick: ClayEnergy): IPanRecipe? {
         val recipe = clayReactor.workable.recipeProvider.searchRecipe(Int.MAX_VALUE, stacks) ?: return null
 
+        // TODO: Ignore white laser
         val finalizedDuration = ceil(recipe.duration.toDouble() / (laserEnergy + 1.0)).toLong()
         return PanRecipe(recipe.inputs, recipe.copyOutputs(), (recipe.cePerTick + laserCostPerTick) * finalizedDuration)
     }

--- a/src/main/kotlin/com/github/trc/clayium/common/pan/factories/CPanRecipeFactory.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/pan/factories/CPanRecipeFactory.kt
@@ -13,14 +13,22 @@ import net.minecraft.world.IBlockAccess
 
 object CPanRecipeFactory : IPanRecipeFactory {
     override fun getEntry(world: IBlockAccess, pos: BlockPos, stacks: List<ItemStack>, laserEnergy: Double, laserCostPerTick: ClayEnergy): IPanRecipe? {
-        val metaTileEntity = world.getMetaTileEntity(pos)
-        if (metaTileEntity is ClayReactorMetaTileEntity) {
-            return getEntryClayReactor(metaTileEntity, stacks, laserEnergy, laserCostPerTick)
+        val metaTileEntity = world.getMetaTileEntity(pos) ?: return null
+
+        val multiblockCapability = metaTileEntity.getCapability(ClayiumTileCapabilities.MULTIBLOCK, null)
+        var machineTier = metaTileEntity.tier.numeric
+
+        if (multiblockCapability != null) {
+            if (metaTileEntity is ClayReactorMetaTileEntity) return getEntryClayReactor(metaTileEntity, stacks, laserEnergy, laserCostPerTick)
+            val multiblockCapability = metaTileEntity.getCapability(ClayiumTileCapabilities.MULTIBLOCK, null)
+                ?: return null
+            if (!multiblockCapability.structureFormed) return null
+            machineTier = multiblockCapability.recipeLogicTier
         }
         val recipe = metaTileEntity
-            ?.getCapability(ClayiumTileCapabilities.RECIPE_LOGIC, null)
+            .getCapability(ClayiumTileCapabilities.RECIPE_LOGIC, null)
             ?.recipeProvider
-            ?.searchRecipe(metaTileEntity.tier.numeric, stacks)
+            ?.searchRecipe(machineTier, stacks)
             ?: return null
 
         return PanRecipe(recipe.inputs, recipe.copyOutputs(), recipe.cePerTick * recipe.duration)


### PR DESCRIPTION
<!-- 
For japanese speakers:
PRのタイトルはChangelogに使われるので、なるべく英語にしてください。
PRの内容は日本語で大丈夫です。
-->
## What
PANに関連するバグをいくつか修正:
- PANアダプタが、隣接する機械のTierを無視するのを修正
- PANアダプタが、隣接する機械のマルチブロック構成状態を無視するのを修正
- PANアダプタが、反応炉レシピに対してレーザを適用しないのを修正
- PANアダプタが、レーザインベントリをセーブしないのを修正
- PANアダプタが、レシピの出力個数に応じてコストを調整するように修正

## Outcome
Fixes #281 
Fixes #282 
Fixes #283 

<!-- This PR template is copied and modified from GTCEu's github repo. -->