### PR TITLE
Fix Laser Interface item name in Japanese

### DIFF
--- a/src/main/resources/assets/clayium/lang/ja_jp.lang
+++ b/src/main/resources/assets/clayium/lang/ja_jp.lang
@@ -388,7 +388,7 @@ machine.clayium.electrolysis_reactor=%s電気精錬機
 machine.clayium.distributor=%s分配機
 machine.clayium.distributor.tooltip1=内部のアイテムを出来るだけ均等に分配しようとする
 
-machine.clayium.laser_proxy=OPA レーザーインターフェース
+machine.clayium.laser_proxy=%sレーザーインターフェース
 machine.clayium.laser_proxy.tooltip1=粘土反応炉に使用
 machine.clayium.laser_proxy.tooltip2=__DETAIL__
 machine.clayium.laser_proxy.tooltip3=マルチブロック装置でなくても、


### PR DESCRIPTION
<!-- 
For japanese speakers:
PRのタイトルはChangelogに使われるので、なるべく英語にしてください。
PRの内容は日本語で大丈夫です。
-->
## What
日本語だと、レーザーインターフェースの名前が全て`OPA レーザーインターフェース`になっていたのを修正する。

<!-- This PR template is copied and modified from GTCEu's github repo. -->