### PR TITLE
Fix `java.lang.NoClassDefFoundError` when opening GUI on a dedicated server

### DIFF
--- a/src/main/kotlin/com/github/trc/clayium/api/metatileentity/MetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/metatileentity/MetaTileEntity.kt
@@ -37,7 +37,7 @@ import com.github.trc.clayium.client.model.ModelTextures
 import com.github.trc.clayium.common.creativetab.ClayiumCTabs
 import com.github.trc.clayium.common.gui.ClayGuiTextures
 import com.github.trc.clayium.common.items.filter.FilterType
-import com.github.trc.clayium.common.util.BothSideI18n
+import com.github.trc.clayium.common.util.SidelessI18n
 import com.github.trc.clayium.common.util.UtilLocale
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap
 import net.minecraft.block.Block
@@ -628,10 +628,10 @@ abstract class MetaTileEntity(
     }
 
     open fun getItemStackDisplayName(): String {
-        return if (BothSideI18n.hasKey("${this.translationKey}.${tier.lowerName}")) {
-            BothSideI18n.format("${this.translationKey}.${tier.lowerName}")
+        return if (SidelessI18n.hasKey("${this.translationKey}.${tier.lowerName}")) {
+            SidelessI18n.format("${this.translationKey}.${tier.lowerName}")
         } else {
-            BothSideI18n.format(this.translationKey, BothSideI18n.format(this.tier.prefixTranslationKey))
+            SidelessI18n.format(this.translationKey, SidelessI18n.format(this.tier.prefixTranslationKey))
         }
     }
 
@@ -726,7 +726,7 @@ abstract class MetaTileEntity(
             .child(IKey.lang("container.inventory").asWidget().align(Alignment.BottomLeft))
             .child(IKey.dynamic {
                 // if empty string, a bug occurs.
-                if (overclock != 1.0) I18n.format("gui.clayium.overclock", overclock) else " "
+                if (overclock != 1.0) SidelessI18n.format("gui.clayium.overclock", overclock) else " "
             }.asWidgetResizing().alignment(Alignment.CenterRight).align(Alignment.BottomRight))
     }
 

--- a/src/main/kotlin/com/github/trc/clayium/api/metatileentity/multiblock/ClayReactorMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/metatileentity/multiblock/ClayReactorMetaTileEntity.kt
@@ -17,8 +17,8 @@ import com.github.trc.clayium.api.util.asWidgetResizing
 import com.github.trc.clayium.api.util.clayiumId
 import com.github.trc.clayium.api.util.getMetaTileEntity
 import com.github.trc.clayium.common.recipe.registry.CRecipes
+import com.github.trc.clayium.common.util.SidelessI18n
 import com.github.trc.clayium.common.util.UtilLocale
-import net.minecraft.client.resources.I18n
 import net.minecraft.util.EnumFacing
 import net.minecraft.util.ResourceLocation
 import net.minecraft.util.math.BlockPos
@@ -81,7 +81,7 @@ class ClayReactorMetaTileEntity(
     override fun buildMainParentWidget(syncManager: PanelSyncManager): ParentWidget<*> {
         syncManager.syncValue("clayLaser", ClayLaserSyncValue(::laser, ::laser::set))
         return super.buildMainParentWidget(syncManager)
-            .child(IKey.dynamic { I18n.format("gui.clayium.laser_energy", UtilLocale.laserNumeral(this.laser?.energy?.toLong() ?: 0L)) }.asWidgetResizing()
+            .child(IKey.dynamic { SidelessI18n.format("gui.clayium.laser_energy", UtilLocale.laserNumeral(this.laser?.energy?.toLong() ?: 0L)) }.asWidgetResizing()
                 .pos(102, 53))
             .child(multiblockLogic.tierTextWidget(syncManager)
                 .alignX(Alignment.Center.x).bottom(12))

--- a/src/main/kotlin/com/github/trc/clayium/api/metatileentity/multiblock/MultiblockLogic.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/metatileentity/multiblock/MultiblockLogic.kt
@@ -14,7 +14,7 @@ import com.github.trc.clayium.api.util.RelativeDirection
 import com.github.trc.clayium.api.util.asWidgetResizing
 import com.github.trc.clayium.api.util.getMetaTileEntity
 import com.github.trc.clayium.common.blocks.BlockMachineHull
-import com.github.trc.clayium.common.util.BothSideI18n
+import com.github.trc.clayium.common.util.SidelessI18n
 import net.minecraft.network.PacketBuffer
 import net.minecraft.util.EnumFacing
 import net.minecraft.util.math.BlockPos
@@ -131,7 +131,7 @@ class MultiblockLogic(
 
     fun tierTextWidget(syncManager: PanelSyncManager): TextWidget {
         syncManager.syncValue("multiblock_tier", SyncHandlers.intNumber({ recipeLogicTier }, { recipeLogicTier = it }))
-        return IKey.dynamic { BothSideI18n.format("tooltip.clayium.tier", recipeLogicTier) }.asWidgetResizing()
+        return IKey.dynamic { SidelessI18n.format("tooltip.clayium.tier", recipeLogicTier) }.asWidgetResizing()
     }
 
     override fun <T> getCapability(capability: Capability<T>, facing: EnumFacing?): T? {

--- a/src/main/kotlin/com/github/trc/clayium/api/metatileentity/multiblock/MultiblockLogic.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/metatileentity/multiblock/MultiblockLogic.kt
@@ -14,7 +14,7 @@ import com.github.trc.clayium.api.util.RelativeDirection
 import com.github.trc.clayium.api.util.asWidgetResizing
 import com.github.trc.clayium.api.util.getMetaTileEntity
 import com.github.trc.clayium.common.blocks.BlockMachineHull
-import net.minecraft.client.resources.I18n
+import com.github.trc.clayium.common.util.BothSideI18n
 import net.minecraft.network.PacketBuffer
 import net.minecraft.util.EnumFacing
 import net.minecraft.util.math.BlockPos
@@ -131,7 +131,7 @@ class MultiblockLogic(
 
     fun tierTextWidget(syncManager: PanelSyncManager): TextWidget {
         syncManager.syncValue("multiblock_tier", SyncHandlers.intNumber({ recipeLogicTier }, { recipeLogicTier = it }))
-        return IKey.dynamic { I18n.format("tooltip.clayium.tier", recipeLogicTier) }.asWidgetResizing()
+        return IKey.dynamic { BothSideI18n.format("tooltip.clayium.tier", recipeLogicTier) }.asWidgetResizing()
     }
 
     override fun <T> getCapability(capability: Capability<T>, facing: EnumFacing?): T? {

--- a/src/main/kotlin/com/github/trc/clayium/api/unification/ore/OrePrefix.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/unification/ore/OrePrefix.kt
@@ -3,7 +3,7 @@ package com.github.trc.clayium.api.unification.ore
 import com.github.trc.clayium.api.FALLBACK
 import com.github.trc.clayium.api.MOD_ID
 import com.github.trc.clayium.api.unification.material.*
-import com.github.trc.clayium.common.util.BothSideI18n
+import com.github.trc.clayium.common.util.SidelessI18n
 import com.google.common.base.CaseFormat
 import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap
 import java.util.function.Predicate
@@ -57,10 +57,10 @@ class OrePrefix(
 
     fun getLocalizedName(material: CMaterial): String {
         val specialKey = "${material.translationKey}.${this.snake}"
-        if (BothSideI18n.hasKey(specialKey)) {
-            return BothSideI18n.format(specialKey)
+        if (SidelessI18n.hasKey(specialKey)) {
+            return SidelessI18n.format(specialKey)
         }
-        return BothSideI18n.format("${MOD_ID}.ore_prefix.${snake}", BothSideI18n.format(material.translationKey))
+        return SidelessI18n.format("${MOD_ID}.ore_prefix.${snake}", SidelessI18n.format(material.translationKey))
     }
 
     override fun toString(): String {

--- a/src/main/kotlin/com/github/trc/clayium/common/metatileentities/CentrifugeMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/metatileentities/CentrifugeMetaTileEntity.kt
@@ -21,7 +21,7 @@ import com.github.trc.clayium.api.util.clayiumId
 import com.github.trc.clayium.common.config.ConfigTierBalance
 import com.github.trc.clayium.common.recipe.registry.CRecipes
 import com.github.trc.clayium.common.util.CNbtUtils
-import net.minecraft.client.resources.I18n
+import com.github.trc.clayium.common.util.SidelessI18n
 import net.minecraft.nbt.NBTTagCompound
 import net.minecraft.util.ResourceLocation
 import net.minecraft.util.math.BlockPos
@@ -72,7 +72,7 @@ class CentrifugeMetaTileEntity(
                 .align(Alignment.TopLeft))
             .child(IKey.lang("container.inventory").asWidget().align(Alignment.BottomLeft))
             .child(IKey.dynamic {
-                if (overclock != 1.0) I18n.format("gui.clayium.overclock", overclock) else " "
+                if (overclock != 1.0) SidelessI18n.format("gui.clayium.overclock", overclock) else " "
             }.asWidgetResizing().alignment(Alignment.CenterRight).align(Alignment.BottomRight))
             .child(slotsAndProgressBar.align(Alignment.Center))
             .child(clayEnergyHolder.createCeTextWidget(syncManager)

--- a/src/main/kotlin/com/github/trc/clayium/common/metatileentities/ChemicalMetalSeparatorMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/metatileentities/ChemicalMetalSeparatorMetaTileEntity.kt
@@ -19,7 +19,7 @@ import com.github.trc.clayium.api.util.ITier
 import com.github.trc.clayium.api.util.asWidgetResizing
 import com.github.trc.clayium.api.util.clayiumId
 import com.github.trc.clayium.common.recipe.registry.CRecipes
-import net.minecraft.client.resources.I18n
+import com.github.trc.clayium.common.util.SidelessI18n
 import net.minecraft.util.ResourceLocation
 
 class ChemicalMetalSeparatorMetaTileEntity(
@@ -59,7 +59,7 @@ class ChemicalMetalSeparatorMetaTileEntity(
                     .child(IKey.lang("container.inventory").asWidget().align(Alignment.BottomLeft))
                     .child(IKey.dynamic {
                         // if empty string, a bug occurs.
-                        if (overclock != 1.0) I18n.format("gui.clayium.overclock", overclock) else " "
+                        if (overclock != 1.0) SidelessI18n.format("gui.clayium.overclock", overclock) else " "
                     }.asWidgetResizing().alignment(Alignment.CenterRight).align(Alignment.BottomRight))
                     .child(slotsAndProgressBar)
                     .child(clayEnergyHolder.createSlotWidget()

--- a/src/main/kotlin/com/github/trc/clayium/common/metatileentities/EnergyConverterMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/metatileentities/EnergyConverterMetaTileEntity.kt
@@ -20,6 +20,7 @@ import com.github.trc.clayium.api.util.ITier
 import com.github.trc.clayium.api.util.MachineIoMode
 import com.github.trc.clayium.api.util.clayiumId
 import com.github.trc.clayium.common.config.ConfigCore
+import com.github.trc.clayium.common.util.SidelessI18n
 import net.minecraft.client.resources.I18n
 import net.minecraft.client.util.ITooltipFlag
 import net.minecraft.item.ItemStack
@@ -96,11 +97,11 @@ class EnergyConverterMetaTileEntity(
             .child(clayEnergyHolder.createCeTextWidget(syncManager)
                 .left(0).bottom(10))
             .child(Column().widthRel(1f).height(8 * 3 + 3 * 2 + 10).align(Alignment.Center)
-                .child(IKey.dynamic { I18n.format("gui.clayium.energy_converter.storage", feStorage.energyStored, feStorage.maxEnergyStored) }
+                .child(IKey.dynamic { SidelessI18n.format("gui.clayium.energy_converter.storage", feStorage.energyStored, feStorage.maxEnergyStored) }
                     .asWidget().widthRel(1f))
-                .child(IKey.dynamic { I18n.format("gui.clayium.energy_converter.rate", cePerTick.format(), fePerTick) }
+                .child(IKey.dynamic { SidelessI18n.format("gui.clayium.energy_converter.rate", cePerTick.format(), fePerTick) }
                     .asWidget().widthRel(1f).margin(0, 3))
-                .child(IKey.dynamic { I18n.format("gui.clayium.energy_converter.output", fePerTick) }
+                .child(IKey.dynamic { SidelessI18n.format("gui.clayium.energy_converter.output", fePerTick) }
                     .asWidget().widthRel(1f))
             )
     }

--- a/src/main/kotlin/com/github/trc/clayium/common/metatileentities/ResonatingCollectorMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/metatileentities/ResonatingCollectorMetaTileEntity.kt
@@ -18,7 +18,7 @@ import com.github.trc.clayium.api.unification.ore.OrePrefix
 import com.github.trc.clayium.api.util.ITier
 import com.github.trc.clayium.api.util.asWidgetResizing
 import com.github.trc.clayium.api.util.clayiumId
-import net.minecraft.client.resources.I18n
+import com.github.trc.clayium.common.util.SidelessI18n
 import net.minecraft.util.EnumFacing
 import net.minecraft.util.ResourceLocation
 
@@ -53,7 +53,7 @@ class ResonatingCollectorMetaTileEntity(
         resonanceManager.sync(syncManager)
         return super.buildMainParentWidget(syncManager)
             .child(IKey.dynamic {
-                I18n.format("gui.$MOD_ID.resonance", NumberFormat.formatWithMaxDigits(resonanceManager.resonance))
+                SidelessI18n.format("gui.$MOD_ID.resonance", NumberFormat.formatWithMaxDigits(resonanceManager.resonance))
             }.asWidgetResizing()
                 .align(Alignment.BottomRight))
             .child(SlotGroupWidget.builder()

--- a/src/main/kotlin/com/github/trc/clayium/common/metatileentities/WaterwheelMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/metatileentities/WaterwheelMetaTileEntity.kt
@@ -19,8 +19,8 @@ import com.github.trc.clayium.api.util.ITier
 import com.github.trc.clayium.api.util.clayiumId
 import com.github.trc.clayium.api.util.getMetaTileEntity
 import com.github.trc.clayium.common.config.ConfigCore
+import com.github.trc.clayium.common.util.SidelessI18n
 import net.minecraft.block.BlockLiquid
-import net.minecraft.client.resources.I18n
 import net.minecraft.init.Blocks
 import net.minecraft.util.EnumFacing
 import net.minecraft.util.ResourceLocation
@@ -88,9 +88,9 @@ class WaterwheelMetaTileEntity(
                         .align(Alignment.TopLeft))
                     .child(IKey.lang("container.inventory").asWidget()
                         .align(Alignment.BottomLeft))
-                    .child(IKey.dynamic { I18n.format("gui.clayium.waterwheel.waters", waterCount) }.asWidget()
+                    .child(IKey.dynamic { SidelessI18n.format("gui.clayium.waterwheel.waters", waterCount) }.asWidget()
                         .widthRel(0.3f).align(Alignment.CenterRight))
-                    .child(IKey.dynamic { I18n.format("gui.clayium.waterwheel.progress", progress) }.asWidget()
+                    .child(IKey.dynamic { SidelessI18n.format("gui.clayium.waterwheel.progress", progress) }.asWidget()
                         .widthRel(0.6f).align(Alignment.CenterLeft)))
                 .child(SlotGroupWidget.playerInventory(0)))
     }

--- a/src/main/kotlin/com/github/trc/clayium/common/metatileentities/multiblock/CaReactorMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/metatileentities/multiblock/CaReactorMetaTileEntity.kt
@@ -25,6 +25,7 @@ import com.github.trc.clayium.common.blocks.BlockCaReactorCoil
 import com.github.trc.clayium.common.blocks.BlockCaReactorHull
 import com.github.trc.clayium.common.recipe.Recipe
 import com.github.trc.clayium.common.recipe.registry.CaReactorRecipeRegistry
+import com.github.trc.clayium.common.util.SidelessI18n
 import it.unimi.dsi.fastutil.ints.IntArrayList
 import net.minecraft.client.resources.I18n
 import net.minecraft.util.EnumFacing
@@ -199,10 +200,10 @@ class CaReactorMetaTileEntity(
                     syncManager.player.sendMessage(err)
                 })
             )
-            .child(IKey.dynamic { I18n.format("gui.clayium.ca_reactor.efficiency", NumberFormat.formatWithMaxDigits(efficiency)) }
+            .child(IKey.dynamic { SidelessI18n.format("gui.clayium.ca_reactor.efficiency", NumberFormat.formatWithMaxDigits(efficiency)) }
                 .asWidgetResizing().alignment(Alignment.CenterRight).alignX(Alignment.BottomRight.x).bottom(14)
             )
-            .child(IKey.dynamic { I18n.format("gui.clayium.ca_reactor.rank_size", avgHullRank, hullCount) }
+            .child(IKey.dynamic { SidelessI18n.format("gui.clayium.ca_reactor.rank_size", avgHullRank, hullCount) }
                 .asWidgetResizing().left(0).top(10))
     }
 

--- a/src/main/kotlin/com/github/trc/clayium/common/metatileentities/multiblock/RedstoneProxyMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/metatileentities/multiblock/RedstoneProxyMetaTileEntity.kt
@@ -16,7 +16,7 @@ import com.github.trc.clayium.api.metatileentity.MetaTileEntity
 import com.github.trc.clayium.api.metatileentity.multiblock.ProxyMetaTileEntityBase
 import com.github.trc.clayium.api.util.ITier
 import com.github.trc.clayium.api.util.clayiumId
-import net.minecraft.client.resources.I18n
+import com.github.trc.clayium.common.util.SidelessI18n
 import net.minecraft.nbt.NBTTagCompound
 import net.minecraft.util.EnumFacing
 import net.minecraft.util.ResourceLocation
@@ -101,7 +101,7 @@ class RedstoneProxyMetaTileEntity(
                 .align(Alignment.Center).widthRel(0.7f).height(24)
                 .length(Mode.entries.size)
                 .value(IntSyncValue({ mode.ordinal }, { i: Int -> mode = Mode.entries[i] }))
-                .overlay(IKey.dynamic { I18n.format(mode.translationKey) })
+                .overlay(IKey.dynamic { SidelessI18n.format(mode.translationKey) })
             )
     }
 

--- a/src/main/kotlin/com/github/trc/clayium/common/util/BothSideI18n.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/util/BothSideI18n.kt
@@ -3,9 +3,12 @@ package com.github.trc.clayium.common.util
 import com.github.trc.clayium.api.util.CUtils
 
 /**
- * Please use it only in places where it is also called from the server.
- * uses [net.minecraft.client.resources.I18n] on the client side. which is the correct way to do it.
- * uses [net.minecraft.util.text.translation.I18n] on the server side, which is deprecated.
+ * Please use it only in places where it is also called from the server, or loaded on the server.
+ * For example, if you use client-only I18n in `IKey.dynamic`, it will throw a ClassNotFoundException on a dedicated server.
+ * So you should use this in such a situation.
+ *
+ * This uses [net.minecraft.client.resources.I18n] on the client side, which is the correct way to do it.
+ * and [net.minecraft.util.text.translation.I18n] on the server side, which is deprecated.
  *
  * **use [net.minecraft.client.resources.I18n] or [net.minecraft.util.text.TextComponentTranslation] whenever possible.**
  */

--- a/src/main/kotlin/com/github/trc/clayium/common/util/SidelessI18n.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/util/SidelessI18n.kt
@@ -13,7 +13,7 @@ import com.github.trc.clayium.api.util.CUtils
  * **use [net.minecraft.client.resources.I18n] or [net.minecraft.util.text.TextComponentTranslation] whenever possible.**
  */
 @Suppress("DEPRECATION")
-object BothSideI18n {
+object SidelessI18n {
     fun format(key: String, vararg args: Any): String {
         return if (CUtils.isClientSide) {
             net.minecraft.client.resources.I18n.format(key, *args)


### PR DESCRIPTION
<!-- 
For japanese speakers:
PRのタイトルはChangelogに使われるので、なるべく英語にしてください。
PRの内容は日本語で大丈夫です。
-->
## What
専用サーバで機械のGUIを開こうとすると`java.lang.NoClassDefFoundError`を吐く問題を修正。

## Implementation Details
前述の問題は、GUIに利用している`IKey.dynamic`の`Supplier`の中で`I18n`を直接呼び出していることが原因であるため、`BothSideI18n`を替わりに利用することで修正した。

## Outcome
Fixes #295 

## Potential Compatibility Issues
None.
<!-- This PR template is copied and modified from GTCEu's github repo. -->