### PR TITLE
Fix wiki deploy CI

### DIFF
--- a/.github/workflows/deploy_wiki.yaml
+++ b/.github/workflows/deploy_wiki.yaml
@@ -2,8 +2,8 @@ name: Deploy Wiki to GitHub Pages
 
 on:
   push:
-    branches:
-      - develop
+#    branches:
+#      - develop
     paths:
       - '.github/workflows/deploy_wiki.yaml'
       - 'wiki/**'

--- a/.github/workflows/deploy_wiki.yaml
+++ b/.github/workflows/deploy_wiki.yaml
@@ -21,6 +21,10 @@ concurrency:
 jobs:
   # Build job
   build:
+    defaults:
+      run:
+        working-directory:
+          wiki
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -31,27 +35,21 @@ jobs:
         uses: pnpm/action-setup@v3
         with:
           version: 9
-          package_json_file: 'wiki/package.json'
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
-          cache-dependency-path: 'wiki/pnpm-lock.yaml'
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Install dependencies
-        run: |
-          cd wiki 
-          pnpm install
+        run: pnpm install
       - name: Build with VitePress
-        run: |
-          cd wiki
-          pnpm docs:build
+        run: pnpm docs:build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: wiki/docs/.vitepress/dist
+          path: docs/.vitepress/dist
 
   # Deployment job
   deploy:

--- a/.github/workflows/deploy_wiki.yaml
+++ b/.github/workflows/deploy_wiki.yaml
@@ -2,8 +2,8 @@ name: Deploy Wiki to GitHub Pages
 
 on:
   push:
-#    branches:
-#      - develop
+    branches:
+      - develop
     paths:
       - '.github/workflows/deploy_wiki.yaml'
       - 'wiki/**'

--- a/.github/workflows/deploy_wiki.yaml
+++ b/.github/workflows/deploy_wiki.yaml
@@ -37,6 +37,7 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
+          cache-dependency-path: 'wiki/pnpm-lock.yaml'
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Install dependencies

--- a/.github/workflows/deploy_wiki.yaml
+++ b/.github/workflows/deploy_wiki.yaml
@@ -18,13 +18,15 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
+defaults:
+  run:
+    working-directory:
+      wiki
+
 jobs:
   # Build job
+
   build:
-    defaults:
-      run:
-        working-directory:
-          wiki
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -35,11 +37,13 @@ jobs:
         uses: pnpm/action-setup@v3
         with:
           version: 9
+          package_json_file: 'wiki/package.json'
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
+          cache-dependency-path: 'wiki/pnpm-lock.yaml'
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Install dependencies
@@ -49,7 +53,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: docs/.vitepress/dist
+          path: wiki/docs/.vitepress/dist
 
   # Deployment job
   deploy:

--- a/.github/workflows/deploy_wiki.yaml
+++ b/.github/workflows/deploy_wiki.yaml
@@ -30,6 +30,7 @@ jobs:
         uses: pnpm/action-setup@v3
         with:
           version: 9
+          package_json_file: 'wiki/package.json'
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -38,9 +39,13 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Install dependencies
-        run: pnpm install
+        run: |
+          cd wiki 
+          pnpm install
       - name: Build with VitePress
-        run: pnpm docs:build
+        run: |
+          cd wiki
+          pnpm docs:build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/deploy_wiki.yaml
+++ b/.github/workflows/deploy_wiki.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
     paths:
+      - '.github/workflows/deploy_wiki.yaml'
       - 'wiki/**'
   workflow_dispatch:
 

--- a/.github/workflows/pr_required_labels.yaml
+++ b/.github/workflows/pr_required_labels.yaml
@@ -7,11 +7,6 @@ name: Pull Request Labels
 
 on:
   pull_request_target:
-    types:
-      - opened
-      - labeled
-      - unlabeled
-      - synchronize
 
 # if a second commit is pushed quickly after the first, cancel the first one's build
 concurrency:

--- a/.github/workflows/pr_required_labels.yaml
+++ b/.github/workflows/pr_required_labels.yaml
@@ -6,7 +6,7 @@
 name: Pull Request Labels
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - labeled

--- a/.github/workflows/pr_required_labels.yaml
+++ b/.github/workflows/pr_required_labels.yaml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
+      contents: read
       pull-requests: write
 
     steps:

--- a/wiki/docs/en/index.md
+++ b/wiki/docs/en/index.md
@@ -5,4 +5,4 @@ A wiki for [Clayium Unofficial](https://github.com/TRCDevelopers/Clayium).
 > [!IMPORTANT]
 > This wiki is currently under construction.
 
-The contents of this wiki are freely available under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) or [MIT-License](../WIKI-LICENSE) unless explicitly stated otherwise.
+The contents of this wiki are freely available under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) or [MIT-License](https://github.com/TRCDevelopers/Clayium/blob/develop/wiki/WIKI-LICENSE) unless explicitly stated otherwise.

--- a/wiki/docs/index.md
+++ b/wiki/docs/index.md
@@ -5,4 +5,4 @@
 > [!IMPORTANT]
 > このWikiは現在作成中です。
 
-このWikiの内容は、明示的に異なる宣言がされてない限り、[CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/)または[MIT-License](../WIKI-LICENSE)のもとで利用可能です。
+このWikiの内容は、明示的に異なる宣言がされてない限り、[CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/)または[MIT-License](https://github.com/TRCDevelopers/Clayium/blob/develop/wiki/WIKI-LICENSE)のもとで利用可能です。


### PR DESCRIPTION
## What
Wikiをdeployするworkflowが[成功](https://github.com/bqc0n/Clayium/actions/runs/15320388801/job/43102682468)するよう修正する。
Deployの部分は失敗しているが、これは`development`ブランチからでないとpagesにdeployできないからなので、おそらく問題ない。