### PR TITLE
fix: wiki edit link is old

### DIFF
--- a/wiki/docs/.vitepress/config/en.ts
+++ b/wiki/docs/.vitepress/config/en.ts
@@ -4,7 +4,7 @@ export const en = defineConfig({
     lang: "en_US",
     themeConfig: {
         editLink: {
-            pattern: "https://github.com/bqc0n/clayium-wiki/edit/main/docs/:path",
+            pattern: "https://github.com/TRCDevelopers/Clayium/edit/develop/wiki/docs/:path",
             text: "Edit this page on GitHub",
         },
         sidebar: {

--- a/wiki/docs/.vitepress/config/ja.ts
+++ b/wiki/docs/.vitepress/config/ja.ts
@@ -4,7 +4,7 @@ export const ja = defineConfig({
     lang: "ja",
     themeConfig: {
         editLink: {
-            pattern: "https://github.com/bqc0n/clayium-wiki/edit/main/docs/:path",
+            pattern: "https://github.com/TRCDevelopers/Clayium/edit/develop/wiki/docs/:path",
             text: "GitHub で編集",
         },
         sidebar: sidebar()


### PR DESCRIPTION
<!-- 
For japanese speakers:
PRのタイトルはChangelogに使われるので、なるべく英語にしてください。
PRの内容は日本語で大丈夫です。
-->
## What
fix wiki edit link to `https://github.com/TRCDevelopers/Clayium/edit/develop/wiki/docs/:path`