### PR TITLE
feat: publish mod on release instead of tag push

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -4,5 +4,7 @@ bug:
   - head-branch: ['^fix', 'fix']
 refactoring:
   - head-branch: ['^refactor', 'refactor']
+"type: ci":
+  - head-branch: ['^ci', 'ci']
 "ignore changelog":
   - head-branch: ['^ignorec', 'ignorec']

--- a/.github/workflows/publish-mod.yaml
+++ b/.github/workflows/publish-mod.yaml
@@ -1,9 +1,8 @@
 name: Publish Mod
 
 on:
-  push:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+  release:
+    types: [published]
 
 env:
   VERSION_TYPE: alpha
@@ -62,11 +61,6 @@ jobs:
             jei(optional)
             groovyscript(optional)
             the-one-probe(optional)
-
-          github-generate-changelog: true
-          github-prerelease: false
-
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
           modrinth-id: m5ogv9xL
           modrinth-featured: true


### PR DESCRIPTION
## What
mc-publishを、tagのpush時ではなく、releaseの作成時に走らせる。

## Outcome
changelogが自動でMod公開platformへ配送される。
公開前に、changelogの細かい調整を行える。

## Additional Information
changelogはデフォルトでreleaseのbodyになる (https://github.com/Kira-NT/mc-publish?tab=readme-ov-file#changelog)