### PR TITLE
CI: publish to github release

### DIFF
--- a/.github/workflows/publish-mod.yaml
+++ b/.github/workflows/publish-mod.yaml
@@ -62,6 +62,8 @@ jobs:
             groovyscript(optional)
             the-one-probe(optional)
 
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
           modrinth-id: m5ogv9xL
           modrinth-featured: true
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ and published on [CurseForge](https://www.curseforge.com/minecraft/mc-mods/clayi
 This mod is currently in alpha stage and may contain critical bugs including game crashes.
 
 ## Required Mods
-- [ModularUI](https://github.com/CleanroomMC/ModularUI) (v2.5.0-rc4)
+- [ModularUI](https://github.com/CleanroomMC/ModularUI) (v2.5.0-rc5)
 - [CodeChickenLib](https://github.com/TheCBProject/CodeChickenLib)
 - [Forgelin Continuous](https://github.com/ChAoSUnItY/Forgelin-Continuous)
 


### PR DESCRIPTION
<!-- 
For japanese speakers:
PRのタイトルはChangelogに使われるので、なるべく英語にしてください。
PRの内容は日本語で大丈夫です。
-->
## What
現状、github releaseを作成するとき、手動でassetsをアップロードする必要がある。
mc-publishにgithub-tokenを渡すことで、自動化できるので、修正。

<!-- This PR template is copied and modified from GTCEu's github repo. -->