### PR TITLE
fix(ci): Run a PR Label checking on reopen/synchronize

### DIFF
--- a/.github/workflows/pr_required_labels.yaml
+++ b/.github/workflows/pr_required_labels.yaml
@@ -7,7 +7,7 @@ name: Pull Request Labels
 
 on:
   pull_request_target:
-    types: ["opened", "labeled", "unlabeled"]
+    types: ["opened", "reopened", "synchronize", "labeled", "unlabeled"]
 
 # if a second commit is pushed quickly after the first, cancel the first one's build
 concurrency:


### PR DESCRIPTION
## What
PRに新しくコミットをプッシュしてもLabelのactionが走らず、status checkをpassしない問題を修正する。