### PR TITLE
fix(ci): correctly enable renovate for only certain dependencies

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -6,8 +6,11 @@
   prConcurrentLimit: 3,
   prHourlyLimit: 6,
   addLabels: ["renovate"],
-  enabled: false,
   packageRules: [
+    {
+      matchBaseBranches: ["*"],
+      enabled: false
+    },
     {
       matchFileNames: ["dependencies.gradle"],
       enabled: true,


### PR DESCRIPTION
`dependencies.gradle`、github-actions、npm にのみ有効にする。