### PR TITLE
Fix(CI): fix labeler, run tests & server if Gradle files changed

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,6 +4,7 @@ changelog:
       - "documentation"
       - "ignore changelog"
       - "type: ci"
+      - "renovate"
 
   categories:
     - title: Added

--- a/.github/workflows/pr_required_labels.yaml
+++ b/.github/workflows/pr_required_labels.yaml
@@ -40,5 +40,5 @@ jobs:
         with:
           mode: minimum
           count: 1
-          labels: 'feature, bug, refactoring, translation, type: ci, ignore changelog'
+          labels: 'feature, bug, refactoring, translation, type: ci, ignore changelog, renovate'
           exit_type: failure

--- a/.github/workflows/run_server.yaml
+++ b/.github/workflows/run_server.yaml
@@ -57,7 +57,7 @@ jobs:
           chmod +x ./.github/actions/test_no_error_reports.sh
           ./.github/actions/test_no_error_reports.sh
 
-      - name: Skip tests (no changes in src/)
+      - name: Skip server run (no changes in src/ or Gradle)
         if: steps.filter.outputs.src_or_gradle_changed == 'false'
         run: |
-          echo "No changes detected in src/. Tests are not required for this PR."
+          echo "No changes detected in src/ or Gradle. Server run is not required for this PR."

--- a/.github/workflows/run_server.yaml
+++ b/.github/workflows/run_server.yaml
@@ -1,4 +1,4 @@
-name: Run Dedicated Server
+name: Build and Run Dedicated Server
 
 on:
   pull_request:
@@ -19,26 +19,30 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # if there are no changes in src/, skip the tests.
-      - name: Check for changes in src
+      # if there are no changes in src/ or Gradle, skip the tests.
+      - name: Check for changes in src and gradle files
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         id: filter # このステップの出力を後で参照できるようにidを設定
         with:
           filters: |
-            src_changed:
+            src_or_gradle_changed:
               - 'src/**'
+              - 'gradle/**'
+              - '**.gradle'
+              - 'gradlew.bat'
+              - 'gradlew'
 
       - name: Grant execute permission for gradlew
-        if: steps.filter.outputs.src_changed == 'true'
+        if: steps.filter.outputs.src_or_gradle_changed == 'true'
         shell: bash
         run: chmod +x gradlew
 
       - name: Setup Build
-        if: steps.filter.outputs.src_changed == 'true'
+        if: steps.filter.outputs.src_or_gradle_changed == 'true'
         uses: ./.github/actions/build_setup
 
       - name: Run Dedicated Server
-        if: steps.filter.outputs.src_changed == 'true'
+        if: steps.filter.outputs.src_or_gradle_changed == 'true'
         shell: bash
         run: |
           mkdir -p run/server
@@ -48,12 +52,12 @@ jobs:
           timeout ${{ env.TIMEOUT }} ./.github/actions/run_server_autostop.sh | tee -a server.log || true
 
       - name: Test no errors reported during the server run
-        if: steps.filter.outputs.src_changed == 'true'
+        if: steps.filter.outputs.src_or_gradle_changed == 'true'
         run: |
           chmod +x ./.github/actions/test_no_error_reports.sh
           ./.github/actions/test_no_error_reports.sh
 
       - name: Skip tests (no changes in src/)
-        if: steps.filter.outputs.src_changed == 'false'
+        if: steps.filter.outputs.src_or_gradle_changed == 'false'
         run: |
           echo "No changes detected in src/. Tests are not required for this PR."

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -30,6 +30,10 @@ jobs:
           filters: |
             src_or_gradle_changed:
               - 'src/**'
+              - 'gradle/**'
+              - '**.gradle'
+              - 'gradlew.bat'
+              - 'gradlew'
 
       - name: Setup Build
         if: steps.filter.outputs.src_or_gradle_changed == 'true'

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       # if there are no changes in src/ or Gradle, skip the tests.
-      - name: Check for changes in src
+      - name: Check for changes in src and gradle files
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         id: filter # このステップの出力を後で参照できるようにidを設定
         with:
@@ -43,7 +43,7 @@ jobs:
         if: steps.filter.outputs.src_or_gradle_changed == 'true'
         run: ./gradlew test --warning-mode all --build-cache
 
-      - name: Skip tests (no changes in src/)
+      - name: Skip tests (no changes in src/ or Gradle)
         if: steps.filter.outputs.src_or_gradle_changed == 'false'
         run: |
-          echo "No changes detected in src/. Tests are not required for this PR."
+          echo "No changes detected in src/ or Gradle. Tests are not required for this PR."

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -22,24 +22,24 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # if there are no changes in src/, skip the tests.
+      # if there are no changes in src/ or Gradle, skip the tests.
       - name: Check for changes in src
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         id: filter # このステップの出力を後で参照できるようにidを設定
         with:
           filters: |
-            src_changed:
+            src_or_gradle_changed:
               - 'src/**'
 
       - name: Setup Build
-        if: steps.filter.outputs.src_changed == 'true'
+        if: steps.filter.outputs.src_or_gradle_changed == 'true'
         uses: ./.github/actions/build_setup
 
       - name: Run Tests with Gradle
-        if: steps.filter.outputs.src_changed == 'true'
+        if: steps.filter.outputs.src_or_gradle_changed == 'true'
         run: ./gradlew test --warning-mode all --build-cache
 
       - name: Skip tests (no changes in src/)
-        if: steps.filter.outputs.src_changed == 'false'
+        if: steps.filter.outputs.src_or_gradle_changed == 'false'
         run: |
           echo "No changes detected in src/. Tests are not required for this PR."


### PR DESCRIPTION
<!-- 
For japanese speakers:
PRのタイトルはChangelogに使われるので、なるべく英語にしてください。
PRの内容は日本語で大丈夫です。
-->
## What
- renovateラベルがついていれば、required labelsをpassし、releaseでは無視されるように設定。
- src/だけでなく、gradle関連のファイルが変更された場合にもテストとサーバーを実行する。