### PR TITLE
Fix: Metal Chests

### DIFF
--- a/src/main/kotlin/com/github/trc/clayium/client/model/MetalChestModel.kt
+++ b/src/main/kotlin/com/github/trc/clayium/client/model/MetalChestModel.kt
@@ -54,7 +54,7 @@ object MetalChestModel : IModel {
             /* gui */
             ItemTransformVec3f(Vector3f(30f, 45f, 0f), zero, Vector3f(0.625f, 0.625f, 0.625f)),
             /* ground */
-            ItemTransformVec3f(zero, Vector3f(0f, 3f, 0f), Vector3f(0.25f, 0.25f, 0.25f)),
+            ItemTransformVec3f(zero, Vector3f(0f, 3f, 0f).apply { scale(0.0625f) }, Vector3f(0.25f, 0.25f, 0.25f)),
             /* fixed */
             ItemTransformVec3f(Vector3f(0f, 180f, 0f), zero, one)
         )

--- a/src/main/kotlin/com/github/trc/clayium/client/renderer/MetalChestItemRenderer.kt
+++ b/src/main/kotlin/com/github/trc/clayium/client/renderer/MetalChestItemRenderer.kt
@@ -11,6 +11,13 @@ object MetalChestItemRenderer : TileEntityItemStackRenderer() {
         val block = item.blockMetalChest
         val material = block.getCMaterial(itemStackIn)
 
-        MetalChestRenderer.render(EnumFacing.SOUTH, material, 0f, 0f, 0.0, 0.0, 0.0, 0f, 0, 1f)
+        MetalChestRenderer.render(
+            facing = EnumFacing.SOUTH,
+            material = material,
+            prevLidAngle = 0f,
+            lidAngle = 0f,
+            x = 0.0, y = 0.0, z = 0.0,
+            partialTicks = 0f, destroyStage = -1,
+            alpha = 1f)
     }
 }

--- a/src/main/kotlin/com/github/trc/clayium/client/renderer/MetalChestRenderer.kt
+++ b/src/main/kotlin/com/github/trc/clayium/client/renderer/MetalChestRenderer.kt
@@ -49,34 +49,48 @@ object MetalChestRenderer : TileEntitySpecialRenderer<TileEntityMetalChest>() {
 
             modelChest.chestLid.rotateAngleX = -(f * (Math.PI.toFloat() / 2f))
 
-            GlStateManager.disableBlend()
-            val colors = material.colors ?: intArrayOf(0xFFFFFF, 0xFFFFFF, 0xFFFFFF)
-            this.bindTexture(base)
-            this.glColorRGB(colors[0], alpha)
-            modelChest.renderAll()
+            if (destroyStage >= 0) {
+                this.bindTexture(DESTROY_STAGES[destroyStage])
+                GlStateManager.matrixMode(GL11.GL_TEXTURE)
+                GlStateManager.pushMatrix()
+                GlStateManager.scale(4.0f, 4.0f, 1.0f)
+                GlStateManager.translate(0.0625f, 0.0625f, 0.0625f)
+                GlStateManager.matrixMode(GL11.GL_MODELVIEW)
 
-            GlStateManager.enableBlend()
-            GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA)
-            GlStateManager.depthMask(false)
+                modelChest.renderAll()
 
-            GlStateManager.enablePolygonOffset()
-            GlStateManager.doPolygonOffset(-0.1f, -1.0f)
-            this.bindTexture(dark)
-            this.glColorRGB(colors[1], alpha)
-            modelChest.renderAll()
+                GlStateManager.matrixMode(GL11.GL_TEXTURE)
+                GlStateManager.popMatrix()
+                GlStateManager.matrixMode(GL11.GL_MODELVIEW)
+            } else {
+                GlStateManager.disableBlend()
+                val colors = material.colors ?: intArrayOf(0xFFFFFF, 0xFFFFFF, 0xFFFFFF)
+                this.bindTexture(base)
+                this.glColorRGB(colors[0], alpha)
+                modelChest.renderAll()
 
-            GlStateManager.doPolygonOffset(-0.2f, -2.0f)
-            this.bindTexture(light)
-            this.glColorRGB(colors[2], alpha)
-            modelChest.renderAll()
+                GlStateManager.enableBlend()
+                GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA)
+                GlStateManager.depthMask(false)
 
-            GlStateManager.depthMask(true)
-            GlStateManager.disablePolygonOffset()
-            GlStateManager.enableAlpha()
-            GlStateManager.disableBlend()
+                GlStateManager.enablePolygonOffset()
+                GlStateManager.doPolygonOffset(-0.1f, -1.0f)
+                this.bindTexture(dark)
+                this.glColorRGB(colors[1], alpha)
+                modelChest.renderAll()
 
-            GlStateManager.color(1f, 1f, 1f, 1f)
+                GlStateManager.doPolygonOffset(-0.2f, -2.0f)
+                this.bindTexture(light)
+                this.glColorRGB(colors[2], alpha)
+                modelChest.renderAll()
+
+                GlStateManager.depthMask(true)
+                GlStateManager.disablePolygonOffset()
+                GlStateManager.enableAlpha()
+                GlStateManager.disableBlend()
+            }
         }
+        GlStateManager.color(1f, 1f, 1f, 1f)
         GlStateManager.disableRescaleNormal()
         GlStateManager.popMatrix()
     }

--- a/src/main/kotlin/com/github/trc/clayium/common/blocks/metalchest/BlockMetalChest.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/blocks/metalchest/BlockMetalChest.kt
@@ -125,14 +125,32 @@ class BlockMetalChest : Block(BlockMaterial.IRON) {
         return worldIn.getTileEntity(pos)?.receiveClientEvent(id, param) ?: super.eventReceived(state, worldIn, pos, id, param)
     }
 
+    private val beingBrokenMeta = ThreadLocal<Int>();
+
     override fun breakBlock(worldIn: World, pos: BlockPos, state: IBlockState) {
         val te = worldIn.getTileEntity(pos) as? TileEntityMetalChest
         if (te != null) {
             for (stack in te.itemDroppedOnDestroy()) {
                 spawnAsEntity(worldIn, pos, stack)
             }
+            beingBrokenMeta.set(te.material.metaItemSubId)
         }
         super.breakBlock(worldIn, pos, state)
+    }
+
+    override fun harvestBlock(worldIn: World, player: EntityPlayer, pos: BlockPos, state: IBlockState, te: TileEntity?, stack: ItemStack) {
+        if (te as? TileEntityMetalChest != null) beingBrokenMeta.set(te.material.metaItemSubId)
+        super.harvestBlock(worldIn, player, pos, state, te, stack)
+        beingBrokenMeta.remove()
+    }
+
+    override fun getDrops(drops: NonNullList<ItemStack?>, world: IBlockAccess, pos: BlockPos, state: IBlockState, fortune: Int) {
+        val te = world.getTileEntity(pos) as? TileEntityMetalChest
+        if (te != null) {
+            drops.add(ItemStack(this, 1, te.material.metaItemSubId))
+        } else {
+            drops.add(ItemStack(this, 1, beingBrokenMeta.get()))
+        }
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/kotlin/com/github/trc/clayium/common/blocks/metalchest/BlockMetalChest.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/blocks/metalchest/BlockMetalChest.kt
@@ -156,6 +156,15 @@ class BlockMetalChest : Block(BlockMaterial.IRON) {
         }
     }
 
+    override fun getPickBlock(state: IBlockState, target: RayTraceResult, world: World, pos: BlockPos, player: EntityPlayer): ItemStack {
+        val te = world.getTileEntity(pos) as? TileEntityMetalChest
+        return if (te != null) {
+            ItemStack(this, 1, te.material.metaItemSubId)
+        } else {
+            ItemStack(this, 1, 0)
+        }
+    }
+
     @SideOnly(Side.CLIENT)
     override fun getRenderType(state: IBlockState) = EnumBlockRenderType.ENTITYBLOCK_ANIMATED
 

--- a/src/main/kotlin/com/github/trc/clayium/common/blocks/metalchest/BlockMetalChest.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/blocks/metalchest/BlockMetalChest.kt
@@ -127,7 +127,7 @@ class BlockMetalChest : Block(BlockMaterial.IRON) {
         return worldIn.getTileEntity(pos)?.receiveClientEvent(id, param) ?: super.eventReceived(state, worldIn, pos, id, param)
     }
 
-    private val beingBrokenMeta = ThreadLocal<Int>();
+    private val beingBrokenMeta = ThreadLocal<Int>()
 
     override fun breakBlock(worldIn: World, pos: BlockPos, state: IBlockState) {
         val te = worldIn.getTileEntity(pos) as? TileEntityMetalChest
@@ -164,6 +164,10 @@ class BlockMetalChest : Block(BlockMaterial.IRON) {
         for (material in ClayiumApi.materialRegistry) {
             ModelLoader.setCustomModelResourceLocation(this.getAsItem(), material.metaItemSubId, itemLoc)
         }
+    }
+
+    override fun hasCustomBreakingProgress(state: IBlockState): Boolean {
+        return true
     }
 
     /* BoilerPlate for custom particle handling */

--- a/src/main/kotlin/com/github/trc/clayium/common/blocks/metalchest/BlockMetalChest.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/blocks/metalchest/BlockMetalChest.kt
@@ -125,6 +125,16 @@ class BlockMetalChest : Block(BlockMaterial.IRON) {
         return worldIn.getTileEntity(pos)?.receiveClientEvent(id, param) ?: super.eventReceived(state, worldIn, pos, id, param)
     }
 
+    override fun breakBlock(worldIn: World, pos: BlockPos, state: IBlockState) {
+        val te = worldIn.getTileEntity(pos) as? TileEntityMetalChest
+        if (te != null) {
+            for (stack in te.itemDroppedOnDestroy()) {
+                spawnAsEntity(worldIn, pos, stack)
+            }
+        }
+        super.breakBlock(worldIn, pos, state)
+    }
+
     @SideOnly(Side.CLIENT)
     override fun getRenderType(state: IBlockState) = EnumBlockRenderType.ENTITYBLOCK_ANIMATED
 

--- a/src/main/kotlin/com/github/trc/clayium/common/blocks/metalchest/BlockMetalChest.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/blocks/metalchest/BlockMetalChest.kt
@@ -49,6 +49,8 @@ class BlockMetalChest : Block(BlockMaterial.IRON) {
     init {
         setCreativeTab(ClayiumCTabs.main)
         setSoundType(SoundType.METAL)
+        setHardness(2.0f)
+        setResistance(2.0f)
     }
 
     override fun createBlockState(): BlockStateContainer {

--- a/src/main/kotlin/com/github/trc/clayium/common/blocks/metalchest/BlockMetalChest.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/blocks/metalchest/BlockMetalChest.kt
@@ -151,7 +151,8 @@ class BlockMetalChest : Block(BlockMaterial.IRON) {
         if (te != null) {
             drops.add(ItemStack(this, 1, te.material.metaItemSubId))
         } else {
-            drops.add(ItemStack(this, 1, beingBrokenMeta.get()))
+            val meta = beingBrokenMeta.get() ?: 0 // Use default value if beingBrokenMeta.get() is null
+            drops.add(ItemStack(this, 1, meta))
         }
     }
 

--- a/src/main/kotlin/com/github/trc/clayium/common/blocks/metalchest/TileEntityMetalChest.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/blocks/metalchest/TileEntityMetalChest.kt
@@ -81,6 +81,15 @@ class TileEntityMetalChest : SyncedTileEntityBase(), ITickable, IGuiHolder<PosGu
         if (!this.world.isRemote) this.markDirty()
     }
 
+    fun itemDroppedOnDestroy(): List<ItemStack> {
+        val stacks = mutableListOf<ItemStack>()
+        for (i in 0..<this.itemInventory.slots) {
+            val stack = this.itemInventory.extractItem(i, Int.MAX_VALUE, false)
+            if (!stack.isEmpty) { stacks.add(stack) }
+        }
+        return stacks
+    }
+
     override fun update() {
         this.prevLidAngle = this.lidAngle
         val open = this.numPlayersUsing > 0 && this.lidAngle == 0.0f

--- a/src/main/kotlin/com/github/trc/clayium/common/blocks/metalchest/TileEntityMetalChest.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/blocks/metalchest/TileEntityMetalChest.kt
@@ -221,7 +221,8 @@ class TileEntityMetalChest : SyncedTileEntityBase(), ITickable, IGuiHolder<PosGu
             )
         }
 
-        val width = max(max(inventoryWidth, 9) * 18 + 14, GUI_DEFAULT_WIDTH + 56)
+        val paddingForPageButtons = if (inventoryPage > 1) 56 else 0
+        val width = max(max(inventoryWidth, 9) * 18 + 14, GUI_DEFAULT_WIDTH + paddingForPageButtons)
         val chestInventoryWidth = inventoryWidth * 18
         val playerInventoryWidth = 162
         val titleTextWidget = if (this.customName != null) {


### PR DESCRIPTION
## What
- 1ページしかない場合、ページボタンがなくなるので、その分GUIの幅を狭くするように
- 壊された時、中のアイテムをドロップしないバグを修正
- 地面に落ちている状態の時、レンダリング位置がずれているのを修正
- ブロックのhardnessとresistanceを修正
- destroy stageがレンダリングされないのを修正