### PR TITLE
Fix: Workable.isWorking is false if recipe's duration is 1 tick

### DIFF
--- a/src/main/kotlin/com/github/trc/clayium/api/capability/AbstractWorkable.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/capability/AbstractWorkable.kt
@@ -5,6 +5,7 @@ import com.cleanroommc.modularui.api.widget.IGuiAction
 import com.cleanroommc.modularui.value.sync.PanelSyncManager
 import com.cleanroommc.modularui.value.sync.SyncHandlers
 import com.cleanroommc.modularui.widgets.ProgressWidget
+import com.github.trc.clayium.api.capability.ClayiumDataCodecs.WORKABLE_STATE
 import com.github.trc.clayium.api.metatileentity.MTETrait
 import com.github.trc.clayium.api.metatileentity.MetaTileEntity
 import com.github.trc.clayium.api.util.CUtils
@@ -19,6 +20,7 @@ import net.minecraft.block.state.IBlockState
 import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.item.ItemStack
 import net.minecraft.nbt.NBTTagCompound
+import net.minecraft.network.PacketBuffer
 import net.minecraft.util.EnumFacing
 import net.minecraft.world.World
 import net.minecraftforge.common.capabilities.Capability
@@ -29,6 +31,18 @@ import kotlin.math.round
 abstract class AbstractWorkable(
     metaTileEntity: MetaTileEntity,
 ) : MTETrait(metaTileEntity, ClayiumDataCodecs.RECIPE_LOGIC), IWorkingControllable {
+
+    var state: State = State.IDLE
+        protected set(value) {
+            val syncFlag = !metaTileEntity.isRemote && field != value
+            if (syncFlag) {
+                writeCustomData(WORKABLE_STATE) {
+                    writeEnumValue(value)
+                }
+            }
+            field = value
+        }
+
     var requiredProgress = 0L
         protected set
     var currentProgress = 0L
@@ -43,13 +57,20 @@ abstract class AbstractWorkable(
      */
     private val isProcessingRecipe: Boolean get() = currentProgress != 0L
 
-    /**
-     * used for Redstone Interfaces.
-     * should be overridden if the machine has 1 tick recipe.
-     */
-    override var isWorking: Boolean = false
-        protected set
-    override var isWorkingEnabled: Boolean = true
+    override val isWorking get() = this.state == State.WORKING
+    override var isWorkingEnabled get() = this.state != State.DISABLED
+        set(value) {
+            if (value) {
+                if (isProcessingRecipe) {
+                    this.state = State.WORKING
+                } else {
+                    this.state = State.IDLE
+                }
+            } else {
+                this.state = State.DISABLED
+            }
+        }
+
     private var canProgress = false
 
     // item stacks that will be produced when the recipe is done
@@ -58,8 +79,10 @@ abstract class AbstractWorkable(
     /**
      * try to search for a new recipe.
      * you should mutate [invalidInputsForRecipes] or [outputsFull] here.
+     *
+     * @return true if a new recipe is found and ready to work, false otherwise.
      */
-    protected abstract fun trySearchNewRecipe()
+    protected abstract fun trySearchNewRecipe(): Boolean
 
     /**
      * Show recipes in JEI.
@@ -71,18 +94,25 @@ abstract class AbstractWorkable(
 
     override fun update() {
         if (metaTileEntity.isRemote) return
-        this.isWorking = isWorkingEnabled && canProgress && isProcessingRecipe
-        if (!isWorkingEnabled) return
-        if (metaTileEntity.offsetTimer % 20 == 0L) {
-            this.canProgress = canProgress()
+        if (this.state == State.DISABLED) return
+
+        if (metaTileEntity.offsetTimer % 20 == 0L) this.canProgress = canProgress()
+
+        if (!canProgress) {
+            this.state = State.IDLE
+            return
         }
-        if (!canProgress) return
 
         // if you updateProgress then searchRecipe, it practically increases recipe duration by 1 tick.
         // this is because when the (recipe output > half of the max stack size),
         // next recipe output cannot fit in the output slot and thus will not match.
         if (!isProcessingRecipe && shouldSearchForRecipe()) {
-            trySearchNewRecipe()
+            val readyToWork = trySearchNewRecipe()
+            if (readyToWork) {
+                this.state = State.WORKING
+            } else {
+                this.state = State.IDLE
+            }
         }
         if (isProcessingRecipe) {
             updateWorkingProgress()
@@ -151,6 +181,24 @@ abstract class AbstractWorkable(
 //        outputsFull = false
 //        metaTileEntity.hasNotifiedOutputs = false
 //        return true
+    }
+
+    override fun writeInitialSyncData(buf: PacketBuffer) {
+        super.writeInitialSyncData(buf)
+        buf.writeEnumValue(state)
+    }
+
+    override fun receiveInitialSyncData(buf: PacketBuffer) {
+        super.receiveInitialSyncData(buf)
+        this.state = buf.readEnumValue(State::class.java)
+    }
+
+    override fun receiveCustomData(discriminator: Int, buf: PacketBuffer) {
+        if (discriminator == WORKABLE_STATE) {
+            this.state = buf.readEnumValue(State::class.java)
+            return
+        }
+        super.receiveCustomData(discriminator, buf)
     }
 
     override fun serializeNBT(): NBTTagCompound {
@@ -234,6 +282,10 @@ abstract class AbstractWorkable(
                     .numberFormat(NumberFormat.COMMAS)
             )
         }
+    }
+
+    enum class State {
+        IDLE, WORKING, DISABLED
     }
 }
 

--- a/src/main/kotlin/com/github/trc/clayium/api/capability/AbstractWorkable.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/capability/AbstractWorkable.kt
@@ -16,6 +16,7 @@ import mcjty.theoneprobe.api.IProbeHitData
 import mcjty.theoneprobe.api.IProbeInfo
 import mcjty.theoneprobe.api.NumberFormat
 import mcjty.theoneprobe.api.ProbeMode
+import mcjty.theoneprobe.api.TextStyleClass
 import net.minecraft.block.state.IBlockState
 import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.item.ItemStack
@@ -254,7 +255,8 @@ abstract class AbstractWorkable(
      * must be annotated with `@Optional.Method(modid = Mods.Names.THE_ONE_PROBE)`
      */
     open fun addProbeInfo(mode: ProbeMode, probeInfo: IProbeInfo, player: EntityPlayer, world: World, state: IBlockState, hitData: IProbeHitData) {
-        if (!isWorking) return
+        // Explicitly Display PAUSED (Change the color of the progress bar) if not isWorkingEnabled
+        if (!isWorking && isWorkingEnabled) return
 
         var progress = currentProgress
         var maxProgress = requiredProgress
@@ -281,6 +283,10 @@ abstract class AbstractWorkable(
                     .borderColor(BORDER_COLOR)
                     .numberFormat(NumberFormat.COMMAS)
             )
+        }
+
+        if (!isWorkingEnabled) {
+            probeInfo.text("${TextStyleClass.WARNING}${IProbeInfo.STARTLOC}gui.clayium.working_paused${IProbeInfo.ENDLOC}")
         }
     }
 

--- a/src/main/kotlin/com/github/trc/clayium/api/capability/AbstractWorkable.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/capability/AbstractWorkable.kt
@@ -47,7 +47,8 @@ abstract class AbstractWorkable(
      * used for Redstone Interfaces.
      * should be overridden if the machine has 1 tick recipe.
      */
-    override val isWorking: Boolean get() = isProcessingRecipe
+    override var isWorking: Boolean = false
+        protected set
     override var isWorkingEnabled: Boolean = true
     private var canProgress = false
 
@@ -69,7 +70,9 @@ abstract class AbstractWorkable(
     protected open fun getTier(): Int = metaTileEntity.tier.numeric
 
     override fun update() {
-        if (metaTileEntity.isRemote || !isWorkingEnabled) return
+        if (metaTileEntity.isRemote) return
+        this.isWorking = isWorkingEnabled && canProgress && isProcessingRecipe
+        if (!isWorkingEnabled) return
         if (metaTileEntity.offsetTimer % 20 == 0L) {
             this.canProgress = canProgress()
         }

--- a/src/main/kotlin/com/github/trc/clayium/api/capability/ClayiumDataCodecs.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/capability/ClayiumDataCodecs.kt
@@ -34,7 +34,7 @@ object ClayiumDataCodecs {
 
     val UPDATE_AREA_RANGE = assignId()
 
-    val WORKABLE_IS_WORKING = assignId()
+    val WORKABLE_STATE = assignId()
 
     val CA_REACTOR_HULL_POSES = assignId()
 

--- a/src/main/kotlin/com/github/trc/clayium/api/capability/impl/AbstractRecipeLogic.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/capability/impl/AbstractRecipeLogic.kt
@@ -28,12 +28,13 @@ abstract class AbstractRecipeLogic(
 
     override var isWorking: Boolean = false
         protected set(value) {
-            field = value
-            if (field != value) {
+            val syncFlag = field != value && !metaTileEntity.isRemote
+            if (syncFlag) {
                 writeCustomData(WORKABLE_IS_WORKING) {
                     writeBoolean(value)
                 }
             }
+            field = value
         }
 
     var recipeCEt = ClayEnergy.ZERO
@@ -95,6 +96,16 @@ abstract class AbstractRecipeLogic(
         val rawCEt = cePt.energy * compensatedFactor.pow(1.5)
         val durationOCed = (duration / compensatedFactor)
         return longArrayOf(rawCEt.toLong(), durationOCed.toLong())
+    }
+
+    override fun writeInitialSyncData(buf: PacketBuffer) {
+        super.writeInitialSyncData(buf)
+        buf.writeBoolean(isWorking)
+    }
+
+    override fun receiveInitialSyncData(buf: PacketBuffer) {
+        super.receiveInitialSyncData(buf)
+        this.isWorking = buf.readBoolean()
     }
 
     override fun serializeNBT(): NBTTagCompound {

--- a/src/main/kotlin/com/github/trc/clayium/api/capability/impl/AbstractRecipeLogic.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/capability/impl/AbstractRecipeLogic.kt
@@ -2,7 +2,6 @@ package com.github.trc.clayium.api.capability.impl
 
 import com.github.trc.clayium.api.ClayEnergy
 import com.github.trc.clayium.api.capability.AbstractWorkable
-import com.github.trc.clayium.api.capability.ClayiumDataCodecs.WORKABLE_IS_WORKING
 import com.github.trc.clayium.api.capability.ClayiumTileCapabilities
 import com.github.trc.clayium.api.metatileentity.MetaTileEntity
 import com.github.trc.clayium.api.recipe.IRecipeProvider
@@ -11,7 +10,6 @@ import com.github.trc.clayium.common.recipe.Recipe
 import com.github.trc.clayium.common.util.TransferUtils
 import com.github.trc.clayium.integration.jei.JeiPlugin
 import net.minecraft.nbt.NBTTagCompound
-import net.minecraft.network.PacketBuffer
 import net.minecraft.util.EnumFacing
 import net.minecraftforge.common.capabilities.Capability
 import kotlin.math.pow
@@ -25,17 +23,6 @@ abstract class AbstractRecipeLogic(
 ) : AbstractWorkable(metaTileEntity) {
 
     protected val inputInventory = metaTileEntity.importItems
-
-    override var isWorking: Boolean = false
-        protected set(value) {
-            val syncFlag = field != value && !metaTileEntity.isRemote
-            if (syncFlag) {
-                writeCustomData(WORKABLE_IS_WORKING) {
-                    writeBoolean(value)
-                }
-            }
-            field = value
-        }
 
     var recipeCEt = ClayEnergy.ZERO
         protected set
@@ -61,15 +48,14 @@ abstract class AbstractRecipeLogic(
         super.updateWorkingProgress()
     }
 
-    override fun trySearchNewRecipe() {
+    override fun trySearchNewRecipe(): Boolean {
         val currentRecipe = recipeProvider.searchRecipe(getTier(), inputInventory.toList())
 
         if (currentRecipe == null) {
             invalidInputsForRecipes = true
-            this.isWorking = false
-            return
+            return false
         }
-        this.isWorking = prepareRecipe(currentRecipe)
+        return prepareRecipe(currentRecipe)
     }
 
     protected open fun prepareRecipe(recipe: Recipe): Boolean {
@@ -98,27 +84,15 @@ abstract class AbstractRecipeLogic(
         return longArrayOf(rawCEt.toLong(), durationOCed.toLong())
     }
 
-    override fun writeInitialSyncData(buf: PacketBuffer) {
-        super.writeInitialSyncData(buf)
-        buf.writeBoolean(isWorking)
-    }
-
-    override fun receiveInitialSyncData(buf: PacketBuffer) {
-        super.receiveInitialSyncData(buf)
-        this.isWorking = buf.readBoolean()
-    }
-
     override fun serializeNBT(): NBTTagCompound {
         val data = super.serializeNBT()
         data.setLong("recipeCEt", recipeCEt.energy)
-        data.setBoolean("isWorking", isWorking)
         return data
     }
 
     override fun deserializeNBT(data: NBTTagCompound) {
         super.deserializeNBT(data)
         recipeCEt = ClayEnergy(data.getLong("recipeCEt"))
-        isWorking = data.getBoolean("isWorking")
     }
 
     override fun <T> getCapability(capability: Capability<T>, facing: EnumFacing?): T? {
@@ -127,13 +101,5 @@ abstract class AbstractRecipeLogic(
         } else {
             super.getCapability(capability, facing)
         }
-    }
-
-    override fun receiveCustomData(discriminator: Int, buf: PacketBuffer) {
-        if (discriminator == WORKABLE_IS_WORKING) {
-            this.isWorking = buf.readBoolean()
-            return
-        }
-        super.receiveCustomData(discriminator, buf)
     }
 }

--- a/src/main/kotlin/com/github/trc/clayium/api/capability/impl/MultiblockRecipeLogic.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/capability/impl/MultiblockRecipeLogic.kt
@@ -10,12 +10,6 @@ open class MultiblockRecipeLogic(
     private val multiblockLogic: MultiblockLogic,
 ) : RecipeLogicEnergy(metaTileEntity, recipeRegistry, metaTileEntity.clayEnergyHolder) {
 
-    override var isWorking: Boolean
-        get() = super.isWorking && multiblockLogic.structureFormed
-        set(value) {
-            super.isWorking = value
-        }
-
     override fun getTier(): Int {
         return multiblockLogic.recipeLogicTier
     }

--- a/src/main/kotlin/com/github/trc/clayium/api/capability/impl/RecipeLogicClayFurnace.kt
+++ b/src/main/kotlin/com/github/trc/clayium/api/capability/impl/RecipeLogicClayFurnace.kt
@@ -19,10 +19,10 @@ class RecipeLogicClayFurnace(
     clayEnergyHolder: ClayEnergyHolder,
 ) : RecipeLogicEnergy(metaTileEntity, registry, clayEnergyHolder) {
 
-    override fun trySearchNewRecipe() {
+    override fun trySearchNewRecipe(): Boolean {
         val smeltingResult = FurnaceRecipes.instance().getSmeltingResult(inputInventory.getStackInSlot(0)).copy()
         if (smeltingResult.isEmpty) return super.trySearchNewRecipe()
-        prepareVanillaFurnaceRecipe(smeltingResult)
+        return prepareVanillaFurnaceRecipe(smeltingResult)
     }
 
     override fun applyOverclock(cePt: ClayEnergy, duration: Long, compensatedFactor: Double): LongArray {
@@ -55,11 +55,11 @@ class RecipeLogicClayFurnace(
         return true
     }
 
-    private fun prepareVanillaFurnaceRecipe(smeltingResult: ItemStack) {
+    private fun prepareVanillaFurnaceRecipe(smeltingResult: ItemStack): Boolean {
         require(!smeltingResult.isEmpty)
         if (!TransferUtils.insertToHandler(metaTileEntity.exportItems, listOf(smeltingResult), true)) {
             this.outputsFull = true
-            return
+            return false
         }
         this.inputInventory.extractItem(0, 1, false)
 
@@ -68,6 +68,7 @@ class RecipeLogicClayFurnace(
         this.recipeCEt = ClayEnergy(cet)
         this.requiredProgress = duration
         this.currentProgress = 1
+        return true
     }
 
     private companion object {

--- a/src/main/kotlin/com/github/trc/clayium/common/metatileentities/AutoTraderMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/metatileentities/AutoTraderMetaTileEntity.kt
@@ -262,15 +262,14 @@ class AutoTraderMetaTileEntity(
             return canFitNewOutputs()
         }
 
-        override fun trySearchNewRecipe() {
+        override fun trySearchNewRecipe(): Boolean {
             // don't use a cached recipe because it may run out of stock
             val recipe = recipeProvider.searchRecipe(getTier(), inputInventory.toList())
             if (recipe == null) {
                 invalidInputsForRecipes = true
-                this.isWorking = false
-                return
+                return false
             }
-            this.isWorking = prepareRecipe(recipe)
+            return prepareRecipe(recipe)
         }
 
         override fun completeWork() {

--- a/src/main/kotlin/com/github/trc/clayium/common/metatileentities/ClayFabricatorMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/metatileentities/ClayFabricatorMetaTileEntity.kt
@@ -84,40 +84,48 @@ class ClayFabricatorMetaTileEntity(
     private inner class ClayFabricatorRecipeLogic : AbstractWorkable(this@ClayFabricatorMetaTileEntity) {
         private var cePerTick = ClayEnergy.ZERO
         var currentCe = ClayEnergy.ZERO
-        override fun trySearchNewRecipe() {
+        override fun trySearchNewRecipe(): Boolean {
             val inputStack = importItems.getStackInSlot(0)
-            if (inputStack.isEmpty) return invalidateInput()
+            if (inputStack.isEmpty) {
+                invalidateInput()
+                return false
+            }
 
             val inputItem = inputStack.item
             if (inputItem == Blocks.CLAY.getAsItem()) {
-                prepareVanillaClay(inputStack.count)
-                return
+                return prepareVanillaClay(inputStack.count)
             }
 
             if (inputItem is ItemBlockMaterial) {
                 val material = inputItem.blockMaterial.getCMaterial(inputStack)
                 val clayProperty = material.getPropOrNull(CPropertyKey.CLAY)
-                if (clayProperty == null || clayProperty.compressionLevel > maxClayCompressionLevel) return invalidateInput()
-                prepareCMaterialClay(material, clayProperty, inputStack.count)
+                if (clayProperty == null || clayProperty.compressionLevel > maxClayCompressionLevel) {
+                    invalidateInput()
+                    return false
+                }
+                return prepareCMaterialClay(material, clayProperty, inputStack.count)
             }
+            invalidateInput()
+            return false
         }
 
-        private fun prepareVanillaClay(count: Int) {
+        private fun prepareVanillaClay(count: Int): Boolean {
             val outputs = listOf(ItemStack(Blocks.CLAY, count))
             if (!TransferUtils.insertToHandler(metaTileEntity.exportItems, outputs, true)) {
                 this.outputsFull = true
-                return
+                return false
             }
             this.itemOutputs = outputs
             this.requiredProgress = 1
             this.currentProgress = 1
+            return true
         }
 
-        private fun prepareCMaterialClay(material: CMaterial, clayProperty: Clay, count: Int) {
+        private fun prepareCMaterialClay(material: CMaterial, clayProperty: Clay, count: Int): Boolean {
             val outputs = listOf(OreDictUnifier.get(OrePrefix.block, material, count))
             if (!TransferUtils.insertToHandler(metaTileEntity.exportItems, outputs, true)) {
                 this.outputsFull = true
-                return
+                return false
             }
             this.itemOutputs = outputs
             this.requiredProgress = (craftTimeLogic(clayProperty.compressionLevel, count) / overclockHandler.compensatedFactor).toLong()
@@ -125,6 +133,7 @@ class ClayFabricatorMetaTileEntity(
             if (clayProperty.energy != null) {
                 this.cePerTick = ClayEnergy((clayProperty.energy * count).energy / this.requiredProgress)
             }
+            return true
         }
 
         override fun updateWorkingProgress() {

--- a/src/main/kotlin/com/github/trc/clayium/common/metatileentities/PanDuplicatorMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/metatileentities/PanDuplicatorMetaTileEntity.kt
@@ -169,23 +169,24 @@ class PanDuplicatorMetaTileEntity(
     }
 
     private inner class PanDuplicatorRecipeLogic : AbstractWorkable(this@PanDuplicatorMetaTileEntity) {
-        override fun trySearchNewRecipe() {
+        override fun trySearchNewRecipe(): Boolean {
             val hasAntimatter = antimatterInput.testItemStackAndAmount(antimatterSlot.getStackInSlot(0))
-            if (!hasAntimatter) return
+            if (!hasAntimatter) return false
             val targetStack = duplicationTargetSlot.getStackInSlot(0)
-            if (targetStack.isEmpty) return
+            if (targetStack.isEmpty) return false
             val duplicationTarget = targetStack.copyWithSize(1)
-            val duplicationCost: ClayEnergy = pan?.getDuplicationEntries()[ItemAndMeta(duplicationTarget)] ?: return
+            val duplicationCost: ClayEnergy = pan?.getDuplicationEntries()[ItemAndMeta(duplicationTarget)] ?: return false
 
             if (!TransferUtils.insertToHandler(metaTileEntity.exportItems, listOf(duplicationTarget), true)) {
                 this.outputsFull = true
-                return
+                return false
             }
 
             antimatterSlot.extractItem(0, 1, false)
             this.requiredProgress = duplicationCost.energy
             this.currentProgress = 1
             this.itemOutputs = listOf(duplicationTarget)
+            return true
         }
 
         override fun updateWorkingProgress() {

--- a/src/main/kotlin/com/github/trc/clayium/common/metatileentities/multiblock/CaReactorMetaTileEntity.kt
+++ b/src/main/kotlin/com/github/trc/clayium/common/metatileentities/multiblock/CaReactorMetaTileEntity.kt
@@ -327,17 +327,17 @@ class CaReactorMetaTileEntity(
     }
 
     private inner class CaReactorRecipeLogic : MultiblockRecipeLogic(this@CaReactorMetaTileEntity, caReactorRegistry, multiblockLogic) {
-        override fun trySearchNewRecipe() {
+        override fun trySearchNewRecipe(): Boolean {
             val recipe = caReactorRegistry.findRecipeWithRank(tier.numeric, avgHullRank, inputInventory.toList())
             if (recipe == null) {
                 invalidInputsForRecipes = true
-                return
+                return false
             }
             val duration = (recipe.duration / efficiency).toLong()
             val cePerTick = ClayEnergy((recipe.cePerTick.energy * cePerTickMultiplier).toLong())
             val multipliedRecipe = Recipe(recipe.inputs, recipe.outputs, recipe.chancedOutputs,
                 duration, cePerTick, recipe.recipeTier)
-            this.isWorking = prepareRecipe(multipliedRecipe)
+            return prepareRecipe(multipliedRecipe)
         }
     }
 }

--- a/src/main/resources/assets/clayium/lang/en_us.lang
+++ b/src/main/resources/assets/clayium/lang/en_us.lang
@@ -8,6 +8,8 @@ itemGroup.clayium.clayiumcapsule=Clayium Fluid Capsules
 
 tooltip.clayium.HoldShiftForDetails=--§fHold §lShift§r For Details§7--
 
+gui.clayium.working_paused=Paused
+
 gui.clayium.laser_energy=Laser \: %1$s
 gui.clayium.resonance=Resonance %1$s
 gui.clayium.overclock=Overclock x%1$s

--- a/src/main/resources/assets/clayium/lang/ja_jp.lang
+++ b/src/main/resources/assets/clayium/lang/ja_jp.lang
@@ -5,6 +5,8 @@ itemGroup.clayium.clayiumcapsule=Clayium 液体カプセル
 
 tooltip.clayium.HoldShiftForDetails=--§f詳細は§lShift§rキー§7--
 
+gui.clayium.working_paused=停止中
+
 gui.clayium.laser_energy=レーザー %1$s
 gui.clayium.resonance=共鳴率 %1$s
 gui.clayium.overclock=オーバークロック x%1$s


### PR DESCRIPTION
## What
レシピの処理時間が1tickである場合に、稼働時出力に設定されたRedstone InterfaceがRedstone信号を出力しない問題を修正する。

## Implementation Details
`isWorking`、`isWorkingEnabled`の2変数で状態を管理するのではなく、IDLE, WORKING, DISABLEDの3つの状態をとる変数Stateを導入した。
また、trySearchNewRecipeが、レシピが存在し処理を開始できたならばtrueを、そうでないならfalseを返すようにした。

## Outcome
Fixes #334 