### PR TITLE
Fix: prevent tool durability consumption for tool-less recipes in ClayWorkTable

### DIFF
--- a/src/main/kotlin/io/github/trcdevelopers/clayium/common/blocks/clayworktable/ClayWorkTableMethod.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/common/blocks/clayworktable/ClayWorkTableMethod.kt
@@ -1,6 +1,7 @@
 package io.github.trcdevelopers.clayium.common.blocks.clayworktable
 
 import io.github.trcdevelopers.clayium.common.items.ClayiumItems
+import net.minecraft.entity.EntityLivingBase
 import net.minecraft.item.Item
 import net.minecraft.item.ItemStack
 
@@ -18,6 +19,17 @@ enum class ClayWorkTableMethod(
 
     fun isValidTool(tool: ItemStack): Boolean {
         return requiredTools.isEmpty() || tool.item in requiredTools
+    }
+
+    /**
+     * Called when a tool is used (button clicked with this method).
+     * @param tool The tool ItemStack used.
+     * @param clicker The EntityLivingBase that clicked the button.
+     */
+    fun damageTool(tool: ItemStack, clicker: EntityLivingBase) {
+        if (tool.item in requiredTools) {
+            tool.damageItem(1, clicker)
+        }
     }
 
     companion object {

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/common/blocks/clayworktable/TileClayWorkTable.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/common/blocks/clayworktable/TileClayWorkTable.kt
@@ -62,7 +62,7 @@ class TileClayWorkTable : TileEntity() {
             craftingProgress = 0
         }
         craftingProgress++
-        currentTool.damageItem(1, clicker)
+        recipe.method.damageTool(currentTool, clicker)
         if (craftingProgress >= requiredProgress) {
             itemHandler.extractItem(0, recipe.input.amount, false)
             completeRecipe(recipe)


### PR DESCRIPTION
## What
粘土作業台に置いたツールが、いかなる場合でも耐久値を消費してしまうバグを修正。
本来、そのツールが必要な場合にのみ耐久値消費されるべき。

## Implementation Details
`ClayWorkTableMethod`に`damageTool`メソッドを追加。
`requiredTools`にアイテムがある場合は耐久値を消費させる。

## Additional Information
拡張性を考えると、Enumはやめたほうがいいのかも。

## Potential Compatibility Issues
None.