### PR TITLE
Disable GUI open/close animation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ modGroup = io.github.trcdevelopers.clayium
 
 # Version of your mod.
 # This field can be left empty if you want your mod's version to be determined by the latest git tag instead.
-modVersion = 0.10.0
+modVersion = 0.11.0-SNAPSHOT
 
 # Whether to use the old jar naming structure (modid-mcversion-version) instead of the new version (modid-version)
 includeMCVersionJar = true

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/api/metatileentity/MetaTileEntity.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/api/metatileentity/MetaTileEntity.kt
@@ -2,7 +2,6 @@ package io.github.trcdevelopers.clayium.api.metatileentity
 
 import com.cleanroommc.modularui.api.drawable.IKey
 import com.cleanroommc.modularui.screen.ModularPanel
-import com.cleanroommc.modularui.screen.ModularScreen
 import com.cleanroommc.modularui.utils.Alignment
 import com.cleanroommc.modularui.value.sync.PanelSyncManager
 import com.cleanroommc.modularui.widget.ParentWidget
@@ -60,7 +59,6 @@ import io.github.trcdevelopers.clayium.common.creativetab.ClayiumCTabs
 import io.github.trcdevelopers.clayium.common.util.SidelessI18n
 import io.github.trcdevelopers.clayium.common.util.UtilLocale
 import io.github.trcdevelopers.clayium.integration.modularui.IGuiHolderClayium
-import io.github.trcdevelopers.clayium.integration.modularui.ModularScreenClayium
 import io.github.trcdevelopers.clayium.integration.modularui.MuiSlots
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap
 import net.minecraft.block.Block
@@ -683,10 +681,6 @@ abstract class MetaTileEntity(
      */
     @SideOnly(Side.CLIENT)
     open fun renderMetaTileEntity(x: Double, y: Double, z: Double, partialTicks: Float) {}
-
-    override fun createScreen(data: MetaTileEntityGuiData, mainPanel: ModularPanel): ModularScreen {
-        return ModularScreenClayium(mainPanel)
-    }
 
     override fun buildUI(data: MetaTileEntityGuiData, syncManager: PanelSyncManager): ModularPanel {
         return ModularPanel.defaultPanel(translationKey)

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/common/blocks/metalchest/TileEntityMetalChest.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/common/blocks/metalchest/TileEntityMetalChest.kt
@@ -1,10 +1,8 @@
 package io.github.trcdevelopers.clayium.common.blocks.metalchest
 
-import com.cleanroommc.modularui.api.IGuiHolder
 import com.cleanroommc.modularui.api.drawable.IKey
 import com.cleanroommc.modularui.factory.PosGuiData
 import com.cleanroommc.modularui.screen.ModularPanel
-import com.cleanroommc.modularui.screen.UISettings
 import com.cleanroommc.modularui.utils.Alignment
 import com.cleanroommc.modularui.value.sync.PanelSyncManager
 import com.cleanroommc.modularui.value.sync.SyncHandlers
@@ -22,6 +20,7 @@ import io.github.trcdevelopers.clayium.api.unification.material.CMaterial
 import io.github.trcdevelopers.clayium.api.unification.material.CMaterials
 import io.github.trcdevelopers.clayium.api.util.CUtils
 import io.github.trcdevelopers.clayium.api.util.asWidgetResizing
+import io.github.trcdevelopers.clayium.integration.modularui.IGuiHolderClayium
 import io.github.trcdevelopers.clayium.integration.modularui.MuiSlots
 import net.minecraft.entity.EntityLivingBase
 import net.minecraft.entity.player.EntityPlayer
@@ -42,7 +41,7 @@ import kotlin.math.min
 
 private const val NUM_PLAYERS_USING_EVENT_ID = 1
 
-class TileEntityMetalChest : SyncedTileEntityBase(), ITickable, IGuiHolder<PosGuiData> {
+class TileEntityMetalChest : SyncedTileEntityBase(), ITickable, IGuiHolderClayium<PosGuiData> {
 
     var material: CMaterial = CMaterials.aluminum
 
@@ -209,7 +208,7 @@ class TileEntityMetalChest : SyncedTileEntityBase(), ITickable, IGuiHolder<PosGu
         return super.hasCapability(capability, facing)
     }
 
-    override fun buildUI(data: PosGuiData, syncManager: PanelSyncManager, settings: UISettings): ModularPanel {
+    override fun buildUI(data: PosGuiData, syncManager: PanelSyncManager): ModularPanel {
         syncManager.registerSlotGroup("metal_chest_inventory", inventoryHeight)
 
         val columnStr = "I".repeat(inventoryWidth)

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/common/items/ItemClayGadgetHolder.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/common/items/ItemClayGadgetHolder.kt
@@ -2,12 +2,10 @@ package io.github.trcdevelopers.clayium.common.items
 
 import baubles.api.BaubleType
 import baubles.api.IBauble
-import com.cleanroommc.modularui.api.IGuiHolder
 import com.cleanroommc.modularui.api.drawable.IKey
 import com.cleanroommc.modularui.factory.HandGuiData
 import com.cleanroommc.modularui.factory.ItemGuiFactory
 import com.cleanroommc.modularui.screen.ModularPanel
-import com.cleanroommc.modularui.screen.UISettings
 import com.cleanroommc.modularui.utils.ItemStackItemHandler
 import com.cleanroommc.modularui.value.sync.PanelSyncManager
 import com.cleanroommc.modularui.widgets.SlotGroupWidget
@@ -18,6 +16,7 @@ import io.github.trcdevelopers.clayium.api.capability.ItemCapabilityProvider
 import io.github.trcdevelopers.clayium.api.util.Mods
 import io.github.trcdevelopers.clayium.common.util.UtilLocale
 import io.github.trcdevelopers.clayium.integration.baubles.BaubleClayGadgets
+import io.github.trcdevelopers.clayium.integration.modularui.IGuiHolderClayium
 import io.github.trcdevelopers.clayium.integration.modularui.MuiSlots
 import net.minecraft.client.util.ITooltipFlag
 import net.minecraft.entity.Entity
@@ -39,7 +38,7 @@ import net.minecraftforge.items.IItemHandlerModifiable
 import java.util.*
 
 @Optional.Interface(iface = "baubles.api.IBauble", modid = Mods.Names.BAUBLES)
-class ItemClayGadgetHolder : Item(), IGuiHolder<HandGuiData>, IBauble {
+class ItemClayGadgetHolder : Item(), IGuiHolderClayium<HandGuiData>, IBauble {
     init {
         maxStackSize = 1
     }
@@ -68,7 +67,7 @@ class ItemClayGadgetHolder : Item(), IGuiHolder<HandGuiData>, IBauble {
         UtilLocale.formatTooltips(tooltip, "clayium.clay_gadget_holder.tooltip")
     }
 
-    override fun buildUI(data: HandGuiData, syncManager: PanelSyncManager, settings: UISettings): ModularPanel {
+    override fun buildUI(data: HandGuiData, syncManager: PanelSyncManager): ModularPanel {
         syncManager.registerSlotGroup("clayium_gadget_holder", 2)
 
         val stack = data.usedItemStack

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/integration/CModIntegration.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/integration/CModIntegration.kt
@@ -1,11 +1,16 @@
 package io.github.trcdevelopers.clayium.integration
 
 import io.github.trcdevelopers.clayium.api.util.Mods
+import io.github.trcdevelopers.clayium.integration.modularui.ModularUiInit
 import io.github.trcdevelopers.clayium.integration.theoneprobe.TheOneProbeModule
 import net.minecraftforge.fml.common.event.FMLInitializationEvent
 
 object CModIntegration {
     fun init(event: FMLInitializationEvent) {
+        // required mods
+        ModularUiInit.init()
+
+        // optional mods
         if (Mods.TheOneProbe.isModLoaded) {
             TheOneProbeModule.init()
         }

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/integration/modularui/IGuiHolderClayium.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/integration/modularui/IGuiHolderClayium.kt
@@ -3,6 +3,7 @@ package io.github.trcdevelopers.clayium.integration.modularui
 import com.cleanroommc.modularui.api.IGuiHolder
 import com.cleanroommc.modularui.factory.GuiData
 import com.cleanroommc.modularui.screen.ModularPanel
+import com.cleanroommc.modularui.screen.ModularScreen
 import com.cleanroommc.modularui.screen.UISettings
 import com.cleanroommc.modularui.value.sync.PanelSyncManager
 
@@ -10,6 +11,11 @@ import com.cleanroommc.modularui.value.sync.PanelSyncManager
  * wraps [IGuiHolder] to absorb changes of MUI API.
  */
 interface IGuiHolderClayium<T: GuiData> : IGuiHolder<T> {
+
+    override fun createScreen(data: T, mainPanel: ModularPanel): ModularScreen {
+        return ModularScreenClayium(mainPanel)
+    }
+
     fun buildUI(data: T, syncManager: PanelSyncManager): ModularPanel
 
     override fun buildUI(data: T, syncManager: PanelSyncManager, settings: UISettings): ModularPanel {

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/integration/modularui/ModularScreenClayium.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/integration/modularui/ModularScreenClayium.kt
@@ -11,6 +11,10 @@ import mezz.jei.transfer.RecipeTransferErrorTooltip
 class ModularScreenClayium(
     panel: ModularPanel
 ) : ModularScreen(panel), JeiRecipeTransferHandler {
+    init {
+        this.useTheme(ModularUiInit.CLAYIUM_DEFAULT_THEME)
+    }
+
     override fun transferRecipe(recipeLayout: IRecipeLayout, maxTransfer: Boolean, simulate: Boolean): IRecipeTransferError {
         return RecipeTransferErrorTooltip("This feature is WIP for Clayium")
     }

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/integration/modularui/ModularUiInit.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/integration/modularui/ModularUiInit.kt
@@ -1,0 +1,17 @@
+package io.github.trcdevelopers.clayium.integration.modularui
+
+import com.cleanroommc.modularui.api.IThemeApi
+import com.cleanroommc.modularui.utils.JsonBuilder
+
+object ModularUiInit {
+
+    const val CLAYIUM_DEFAULT_THEME = "clayium:default"
+
+    fun init() {
+        val theme = JsonBuilder()
+            .add("parent", "DEFAULT")
+            .add("openCloseAnimation", 0)
+            .add("tooltipPos", "NEXT_TO_MOUSE")
+        IThemeApi.get().registerTheme(CLAYIUM_DEFAULT_THEME, theme)
+    }
+}


### PR DESCRIPTION
## What
SSIA

## Implementation Details
ModularUIには[Theme API](https://cleanroommc.com/wiki/modularui/themes)があり、これを利用することで実現可能。詳細は`com.cleanroommc.modularui.theme.ThemeJson.deserialize()`を確認してほしい。
```kotlin
val theme = JsonBuilder()
    .add("parent", "DEFAULT")
    .add("openCloseAnimation", 0)
    .add("tooltipPos", "NEXT_TO_MOUSE")
IThemeApi.get().registerTheme(CLAYIUM_DEFAULT_THEME, theme)
```

`IGuiHolderClayium`が、`createScreen`で`ModularScreenClayium`を返すようにした。このModularScreenClayiumがコンストラクタでuseThemeを呼び出すことにより、`IGuiHolderClayium`を実装するGUI全てでアニメーションが無効化される。

## Additional Information
`IGuiHolderClayium`は、もとは`uiSettings`引数の追加を吸収するものだった。今は`uiSettings`を利用したい状況がないので問題ないが、もし利用したい状況が生まれた場合、`uiSettings`を引数にとらない方も必ず実装しなければならない。この問題については要検討。