### PR TITLE
fix UnsatisfiedLinkError on MacOS

### DIFF
--- a/src/main/java/io/github/trcdevelopers/clayium/mixins/ClayiumMixinConfigPlugin.java
+++ b/src/main/java/io/github/trcdevelopers/clayium/mixins/ClayiumMixinConfigPlugin.java
@@ -1,0 +1,48 @@
+package io.github.trcdevelopers.clayium.mixins;
+
+import io.github.trcdevelopers.clayium.api.util.CUtils;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+public class ClayiumMixinConfigPlugin implements IMixinConfigPlugin {
+    @Override
+    public void onLoad(String mixinPackage) {
+
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return "";
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        // Mixin Narrator is enabled only in deobf environment
+        return CUtils.INSTANCE.isDeobfEnvironment() || !mixinClassName.endsWith("MixinNarrator");
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+
+    }
+
+    @Override
+    public List<String> getMixins() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+
+    }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+
+    }
+}

--- a/src/main/java/io/github/trcdevelopers/clayium/mixins/patch/MixinNarrator.java
+++ b/src/main/java/io/github/trcdevelopers/clayium/mixins/patch/MixinNarrator.java
@@ -1,0 +1,20 @@
+package io.github.trcdevelopers.clayium.mixins.patch;
+
+import com.mojang.text2speech.Narrator;
+import com.mojang.text2speech.NarratorDummy;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+@Mixin(value = Narrator.class, remap = false)
+public interface MixinNarrator {
+
+    /**
+     * @author bqc0n
+     * @reason NarratorOSX {@link com.mojang.text2speech.NarratorOSX} causes UnsatisfiedLinkError on Apple Silicon Macs
+     * (Maybe native libs are not available in arm64 Java 8 JDKs?).
+     * This mixin should be enabled only on deobf environment.
+     */
+    @Overwrite(remap = false)
+    static Narrator getNarrator() {
+        return new NarratorDummy();
+    }
+}

--- a/src/main/java/io/github/trcdevelopers/clayium/mixins/patch/MixinNarrator.java
+++ b/src/main/java/io/github/trcdevelopers/clayium/mixins/patch/MixinNarrator.java
@@ -4,6 +4,7 @@ import com.mojang.text2speech.Narrator;
 import com.mojang.text2speech.NarratorDummy;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
+
 @Mixin(value = Narrator.class, remap = false)
 public interface MixinNarrator {
 

--- a/src/main/resources/mixins.clayium.json
+++ b/src/main/resources/mixins.clayium.json
@@ -4,7 +4,9 @@
   "target": "@env(DEFAULT)",
   "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
+  "plugin": "io.github.trcdevelopers.clayium.mixins.ClayiumMixinConfigPlugin",
   "mixins": [
+    "patch.MixinNarrator"
   ],
   "client": [],
   "server": []


### PR DESCRIPTION
`NarratorOSX`がネイティブライブラリを読み込もうとしてUnsatisfiedLinkErrorを吐くので、Mixinで`NarratorDummy`を替わりに返すようにした。

なお、このMixinはdeobf環境でしか呼ばれないようになっている。