### PR TITLE
Fix material amount inconsistency with GT

### DIFF
--- a/src/main/kotlin/io/github/trcdevelopers/clayium/common/ClayiumMod.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/common/ClayiumMod.kt
@@ -20,7 +20,7 @@ import org.apache.logging.log4j.core.config.Configurator
     acceptedMinecraftVersions = "[1.12.2,1.13)",
     modLanguageAdapter = "io.github.chaosunity.forgelin.KotlinAdapter",
     dependencies = "required:forge@[14.23.5.2847,);" +
-            "required-after:forgelin_continuous@[2.2.20.0,);" +
+            "required-after:forgelin_continuous@[2.0.0.0,);" +
             "required-after:modularui@[3.0.4,);" +
             "required-after:codechickenlib@[3.2.3,);" +
             "required-after:mixinbooter@[9.1,);" +

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/common/loaders/recipe/GrinderRecipeLoader.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/common/loaders/recipe/GrinderRecipeLoader.kt
@@ -2,7 +2,9 @@ package io.github.trcdevelopers.clayium.common.loaders.recipe
 
 import io.github.trcdevelopers.clayium.api.ClayEnergy
 import io.github.trcdevelopers.clayium.api.unification.OreDictUnifier
+import io.github.trcdevelopers.clayium.api.unification.material.CMaterial
 import io.github.trcdevelopers.clayium.api.unification.material.CMaterials
+import io.github.trcdevelopers.clayium.api.unification.material.CPropertyKey
 import io.github.trcdevelopers.clayium.api.unification.material.IMaterial
 import io.github.trcdevelopers.clayium.api.unification.material.MaterialAmount
 import io.github.trcdevelopers.clayium.api.unification.ore.OrePrefix
@@ -109,10 +111,12 @@ object GrinderRecipeLoader {
             if (!OreDictUnifier.exists(prefix, material)) continue
             when (prefix) {
                 block -> handleBlockGrinding(material)
-                ingot, gem, crystal,
+                ingot, gem, crystal -> addDefaultGrindingRecipe(prefix, material)
                 bearing, blade, cuttingHead, cylinder, disc,
-                gear, grindingHead, needle, pipe, ring, spindle -> {
-                    addDefaultGrindingRecipe(prefix, material)
+                gear, grindingHead, needle, pipe, ring, spindle-> {
+                    if (material is CMaterial && material.hasProperty(CPropertyKey.CLAY))  {
+                        addDefaultGrindingRecipe(prefix, material)
+                    }
                 }
             }
         }
@@ -132,7 +136,7 @@ object GrinderRecipeLoader {
         val mAmount = orePrefix.getMaterialAmount(material)
         if (mAmount == MaterialAmount.NONE) return
         val durationModifier = floor(sqrt(mAmount.dustAmount.toDouble())).toInt()
-        val amount = mAmount.dustAmount.toInt()
+        val amount = mAmount.dustAmount
         CRecipes.GRINDER.builder()
             .input(orePrefix, material)
             .output(OrePrefix.dust, material, amount)

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/common/recipe/handler/MaterialRecipeHandler.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/common/recipe/handler/MaterialRecipeHandler.kt
@@ -22,8 +22,9 @@ object MaterialRecipeHandler {
         for (material in ClayiumApi.materialRegistry) {
             GrinderRecipeLoader.handleOre(material)
 
-            if (!material.hasOre(OrePrefix.ingot))
+            if (!material.hasOre(OrePrefix.ingot)) {
                 CondenserRecipeLoader.handleOre(material)
+            }
 
             if (material.hasOre(OrePrefix.ingot)) {
                 if (material.hasProperty(CPropertyKey.PLATE)) addPlateRecipe(OrePrefix.ingot, material)


### PR DESCRIPTION
## What
- In GregTech, 4 rings are created from 1 ingot, but Clayium adds 1 ring to 1 dust grinding recipe for the all metal materials, so infinite materials. This PR fixes this by limiting bearing, blade, cuttingHead, cylinder, disc, gear, grindingHead, needle, pipe, ring, spindle grinding recipes to clay materials only.