### PR TITLE
fix: recipe for clay bending machine was incorrect

### DIFF
--- a/src/main/kotlin/io/github/trcdevelopers/clayium/common/loaders/recipe/MachineBlockRecipeLoader.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/common/loaders/recipe/MachineBlockRecipeLoader.kt
@@ -182,7 +182,7 @@ object MachineBlockRecipeLoader {
         registerMachineRecipeHull(MetaTileEntities.BENDING_MACHINE) {
             input(OrePrefix.plate, CMaterials.denseClay, 3)
         }
-        registerLowTierRecipe(MetaTileEntities.BENDING_MACHINE, "Sgp", "pHp", "Sgp")
+        registerLowTierRecipe(MetaTileEntities.BENDING_MACHINE, "MIg", "pHp", "MIg")
         registerMachineRecipeHull(MetaTileEntities.MILLING_MACHINE) {
             input(OrePrefix.cuttingHead, CMaterials.denseClay)
         }


### PR DESCRIPTION
<!-- 
For japanese speakers:
PRのタイトルはChangelogに使われるので、なるべく英語にしてください。
PRの内容は日本語で大丈夫です。
-->
## What
Clay Bending Machine (粘土プレート作成機)のレシピが間違っていた問題の修正