### PR TITLE
fix: shift-click priority for ClayWorkTable's tool slot was wrong

### DIFF
--- a/src/main/kotlin/io/github/trcdevelopers/clayium/common/blocks/clayworktable/TileClayWorkTable.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/common/blocks/clayworktable/TileClayWorkTable.kt
@@ -158,7 +158,7 @@ class TileClayWorkTable : TileEntity(), IGuiHolderClayium<PosGuiData> {
                         .right(9).top(47)
                     )
                     .child(MuiSlots.itemSlotBuilder(this.itemHandler, TOOL_SLOT)
-                        .singletonSlotGroup(SlotGroup.STORAGE_SLOT_PRIO + 1)
+                        .singletonSlotGroup(SlotGroup.STORAGE_SLOT_PRIO - 1)
                         // TODO: Use capability
                         .filter { s -> ClayWorkTableMethod.entries.any { s.item in it.requiredTools } }
                         .build()


### PR DESCRIPTION
<!-- 
For japanese speakers:
PRのタイトルはChangelogに使われるので、なるべく英語にしてください。
PRの内容は日本語で大丈夫です。
-->
## What
ClayWorkTableのツールスロットのシフトクリックに対する優先度が間違っていた問題の修正

## Implementation Details
Priorityが定数+1になっていたので定数-1にすることによりそのスロットの優先度を上げた。

## Outcome
#401 の修正