### PR TITLE
ci: add version comment for  over-sh/setup-bun

### DIFF
--- a/.github/workflows/deploy_wiki.yaml
+++ b/.github/workflows/deploy_wiki.yaml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 0 # Not needed if lastUpdated is not enabled
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
         with:
           bun-version: 1.3.2
 


### PR DESCRIPTION
SSIA.
version commentがないとrenovateがmasterに追従してしまうため。