### PR TITLE
CI: use Java 21 for gradle & printVersion task

### DIFF
--- a/.github/actions/build_setup/action.yaml
+++ b/.github/actions/build_setup/action.yaml
@@ -23,8 +23,8 @@ runs:
       uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
       with:
         java-version: |
-          21
           8
+          21
         distribution: zulu
 
     - name: Setup Gradle

--- a/.github/actions/build_setup/action.yaml
+++ b/.github/actions/build_setup/action.yaml
@@ -19,10 +19,12 @@ runs:
     - name: Validate Gradle Wrapper
       uses: gradle/actions/wrapper-validation@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0
 
-    - name: Set up JDK 8
+    - name: Setup Java
       uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
       with:
-        java-version: 8
+        java-version: |
+          21
+          8
         distribution: zulu
 
     - name: Setup Gradle

--- a/.github/workflows/publish-mod.yaml
+++ b/.github/workflows/publish-mod.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Get Mod Version
         id: get_mod_version
         run: |
-          VERSION=$(grep "^modVersion" gradle.properties | awk '{print $3}')
+          VERSION=$(./gradlew printVersion | grep -E "\d+\.\d+\.\d+-\d+\.\d+\.\d+")
           echo "Version is $VERSION"
           echo "mod_version=$VERSION" >> $GITHUB_ENV
 

--- a/.github/workflows/publish-mod.yaml
+++ b/.github/workflows/publish-mod.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Get Mod Version
         id: get_mod_version
         run: |
-          VERSION=$(./gradlew -q printVersion | grep -E "[0-9]+\.[0-9]+\.[0-9]+-[0-9]+\.[0-9]+\.[0-9]+")
+          VERSION=$(./gradlew -q printVersion | grep -E "^[0-9]+(\.[0-9]+)*-[0-9]+(\.[0-9]+)*$"
           echo "Version is $VERSION"
           echo "mod_version=$VERSION" >> $GITHUB_ENV
 

--- a/.github/workflows/publish-mod.yaml
+++ b/.github/workflows/publish-mod.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Get Mod Version
         id: get_mod_version
         run: |
-          VERSION=$(./gradlew printVersion | grep -E "[0-9]+\.[0-9]+\.[0-9]+-[0-9]+\.[0-9]+\.[0-9]+")
+          VERSION=$(./gradlew -q printVersion | grep -E "[0-9]+\.[0-9]+\.[0-9]+-[0-9]+\.[0-9]+\.[0-9]+")
           echo "Version is $VERSION"
           echo "mod_version=$VERSION" >> $GITHUB_ENV
 

--- a/.github/workflows/publish-mod.yaml
+++ b/.github/workflows/publish-mod.yaml
@@ -26,7 +26,9 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
-          java-version: '8'
+          java-version: |
+            8
+            21
           distribution: 'temurin'
 
       # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.

--- a/.github/workflows/publish-mod.yaml
+++ b/.github/workflows/publish-mod.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Get Mod Version
         id: get_mod_version
         run: |
-          VERSION=$(./gradlew -q printVersion | grep -E "^[0-9]+(\.[0-9]+)*-[0-9]+(\.[0-9]+)*$"
+          VERSION=$(./gradlew -q printVersion | grep -E "^[0-9]+(\.[0-9]+)*-[0-9]+(\.[0-9]+)*$")
           echo "Version is $VERSION"
           echo "mod_version=$VERSION" >> $GITHUB_ENV
 

--- a/.github/workflows/publish-mod.yaml
+++ b/.github/workflows/publish-mod.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Get Mod Version
         id: get_mod_version
         run: |
-          VERSION=$(./gradlew printVersion | grep -E "\d+\.\d+\.\d+-\d+\.\d+\.\d+")
+          VERSION=$(./gradlew printVersion | grep -E "[0-9]+\.[0-9]+\.[0-9]+-[0-9]+\.[0-9]+\.[0-9]+")
           echo "Version is $VERSION"
           echo "mod_version=$VERSION" >> $GITHUB_ENV
 

--- a/.github/workflows/run_server.yaml
+++ b/.github/workflows/run_server.yaml
@@ -25,7 +25,9 @@ jobs:
         id: filter # このステップの出力を後で参照できるようにidを設定
         with:
           filters: |
-            src_or_gradle_changed:
+            src_or_gradle_or_ci_changed:
+              - '.github/actions/build_setup/**'
+              - '.github/workflows/run_server.yaml'
               - 'src/**'
               - 'gradle/**'
               - '**.gradle'
@@ -33,16 +35,16 @@ jobs:
               - 'gradlew'
 
       - name: Grant execute permission for gradlew
-        if: steps.filter.outputs.src_or_gradle_changed == 'true'
+        if: steps.filter.outputs.src_or_gradle_or_ci_changed == 'true'
         shell: bash
         run: chmod +x gradlew
 
       - name: Setup Build
-        if: steps.filter.outputs.src_or_gradle_changed == 'true'
+        if: steps.filter.outputs.src_or_gradle_or_ci_changed == 'true'
         uses: ./.github/actions/build_setup
 
       - name: Run Dedicated Server
-        if: steps.filter.outputs.src_or_gradle_changed == 'true'
+        if: steps.filter.outputs.src_or_gradle_or_ci_changed == 'true'
         shell: bash
         run: |
           mkdir -p run/server
@@ -52,12 +54,12 @@ jobs:
           timeout ${{ env.TIMEOUT }} ./.github/actions/run_server_autostop.sh | tee -a server.log || true
 
       - name: Test no errors reported during the server run
-        if: steps.filter.outputs.src_or_gradle_changed == 'true'
+        if: steps.filter.outputs.src_or_gradle_or_ci_changed == 'true'
         run: |
           chmod +x ./.github/actions/test_no_error_reports.sh
           ./.github/actions/test_no_error_reports.sh
 
       - name: Skip server run (no changes in src/ or Gradle)
-        if: steps.filter.outputs.src_or_gradle_changed == 'false'
+        if: steps.filter.outputs.src_or_gradle_or_ci_changed == 'false'
         run: |
           echo "No changes detected in src/ or Gradle. Server run is not required for this PR."

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -28,7 +28,9 @@ jobs:
         id: filter # このステップの出力を後で参照できるようにidを設定
         with:
           filters: |
-            src_or_gradle_changed:
+            src_or_gradle_or_ci_changed:
+              - '.github/actions/build_setup/**'
+              - '.github/workflows/run_tests.yaml'
               - 'src/**'
               - 'gradle/**'
               - '**.gradle'
@@ -36,14 +38,14 @@ jobs:
               - 'gradlew'
 
       - name: Setup Build
-        if: steps.filter.outputs.src_or_gradle_changed == 'true'
+        if: steps.filter.outputs.src_or_gradle_or_ci_changed == 'true'
         uses: ./.github/actions/build_setup
 
       - name: Run Tests with Gradle
-        if: steps.filter.outputs.src_or_gradle_changed == 'true'
+        if: steps.filter.outputs.src_or_gradle_or_ci_changed == 'true'
         run: ./gradlew test --warning-mode all --build-cache
 
       - name: Skip tests (no changes in src/ or Gradle)
-        if: steps.filter.outputs.src_or_gradle_changed == 'false'
+        if: steps.filter.outputs.src_or_gradle_or_ci_changed == 'false'
         run: |
           echo "No changes detected in src/ or Gradle. Tests are not required for this PR."

--- a/.github/workflows/test-printversion.yaml.yml
+++ b/.github/workflows/test-printversion.yaml.yml
@@ -15,5 +15,9 @@ jobs:
       - name: Setup Build
         uses: ./.github/actions/build_setup
 
-      - name: Run printVersion
-        run: ./gradlew -q printVersion
+      - name: Get Mod Version
+        id: get_mod_version
+        run: |
+          VERSION=$(./gradlew printVersion | grep -E "\d+\.\d+\.\d+-\d+\.\d+\.\d+")
+          echo "Version is $VERSION"
+          echo "mod_version=$VERSION" >> $GITHUB_ENV

--- a/.github/workflows/test-printversion.yaml.yml
+++ b/.github/workflows/test-printversion.yaml.yml
@@ -21,5 +21,5 @@ jobs:
         id: get_mod_version
         run: |
           set -euo pipefail
-          VERSION=$(./gradlew -q printVersion | grep -E "^[0-9]+(\.[0-9]+)*-[0-9]+(\.[0-9]+)*$"
+          VERSION=$(./gradlew -q printVersion | grep -E "^[0-9]+(\.[0-9]+)*-[0-9]+(\.[0-9]+)*$")
           echo "Version is $VERSION"

--- a/.github/workflows/test-printversion.yaml.yml
+++ b/.github/workflows/test-printversion.yaml.yml
@@ -1,0 +1,18 @@
+name: Run printVersion Task
+on:
+  pull_request:
+
+jobs:
+  run-printversion:
+    name: Run printVersion Task
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Setup Build
+        uses: ./.github/actions/build_setup
+
+      - name: Run printVersion
+        run: ./gradlew -q printVersion

--- a/.github/workflows/test-printversion.yaml.yml
+++ b/.github/workflows/test-printversion.yaml.yml
@@ -21,5 +21,5 @@ jobs:
         id: get_mod_version
         run: |
           set -euo pipefail
-          VERSION=$(./gradlew -q printVersion | grep -E "[0-9]+\.[0-9]+\.[0-9]+-[0-9]+\.[0-9]+\.[0-9]+")
+          VERSION=$(./gradlew -q printVersion | grep -E "^[0-9]+(\.[0-9]+)*-[0-9]+(\.[0-9]+)*$"
           echo "Version is $VERSION"

--- a/.github/workflows/test-printversion.yaml.yml
+++ b/.github/workflows/test-printversion.yaml.yml
@@ -15,9 +15,13 @@ jobs:
       - name: Setup Build
         uses: ./.github/actions/build_setup
 
+      - name: Debug - raw printVersion output
+        run: ./gradlew printVersion
+
       - name: Get Mod Version
         id: get_mod_version
         run: |
-          VERSION=$(./gradlew printVersion | grep -E "\d+\.\d+\.\d+-\d+\.\d+\.\d+")
+          set -euo pipefail
+          VERSION=$(./gradlew printVersion | grep -E "[0-9]+\.[0-9]+\.[0-9]+-[0-9]+\.[0-9]+\.[0-9]+")
           echo "Version is $VERSION"
           echo "mod_version=$VERSION" >> $GITHUB_ENV

--- a/.github/workflows/test-printversion.yaml.yml
+++ b/.github/workflows/test-printversion.yaml.yml
@@ -1,7 +1,6 @@
 name: Run printVersion Task
 on:
   workflow_dispatch:
-  pull_request:
 
 jobs:
   run-printversion:
@@ -24,4 +23,3 @@ jobs:
           set -euo pipefail
           VERSION=$(./gradlew printVersion | grep -E "[0-9]+\.[0-9]+\.[0-9]+-[0-9]+\.[0-9]+\.[0-9]+")
           echo "Version is $VERSION"
-          echo "mod_version=$VERSION" >> $GITHUB_ENV

--- a/.github/workflows/test-printversion.yaml.yml
+++ b/.github/workflows/test-printversion.yaml.yml
@@ -15,11 +15,11 @@ jobs:
         uses: ./.github/actions/build_setup
 
       - name: Debug - raw printVersion output
-        run: ./gradlew printVersion
+        run: ./gradlew -q printVersion
 
       - name: Get Mod Version
         id: get_mod_version
         run: |
           set -euo pipefail
-          VERSION=$(./gradlew printVersion | grep -E "[0-9]+\.[0-9]+\.[0-9]+-[0-9]+\.[0-9]+\.[0-9]+")
+          VERSION=$(./gradlew -q printVersion | grep -E "[0-9]+\.[0-9]+\.[0-9]+-[0-9]+\.[0-9]+\.[0-9]+")
           echo "Version is $VERSION"

--- a/.github/workflows/test-printversion.yaml.yml
+++ b/.github/workflows/test-printversion.yaml.yml
@@ -1,5 +1,6 @@
 name: Run printVersion Task
 on:
+  workflow_dispatch:
   pull_request:
 
 jobs:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -289,3 +289,9 @@ tasks.withType<Javadoc> {
     options.encoding = "UTF-8"
     options.locale = "en_US"
 }
+
+tasks.register("printVersion") {
+    doLast {
+        println(project.version)
+    }
+}


### PR DESCRIPTION
## What
- retroFuturaGradleについて、java 8で動かすことが非推奨になったので、CI環境でもjava 21で動くように修正。Mod 自体のビルドはjava 8のまま動かす。
- printVersion taskをgradleに追加
- publish-mod は printVersion gradle taskを使うように修正