### PR TITLE
Display item name on the Storage Container

### DIFF
--- a/src/main/kotlin/io/github/trcdevelopers/clayium/client/renderer/CRenderUtils.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/client/renderer/CRenderUtils.kt
@@ -41,24 +41,20 @@ object CRenderUtils {
         GlStateManager.enableTexture2D()
     }
 
+    /**
+     * Draws given text with given color and a semi-transparent black background at a current scale/position.
+     */
     fun renderStringWithBackground(text: String, color: Int) {
         val mc = Minecraft.getMinecraft()
         GlStateManager.pushMatrix()
         val memory = memoryCurrentStates()
-        enableTranslucent()
         run {
             GlStateManager.glNormal3f(0.0f, 1.0f, 0.0f)
-            GlStateManager.depthMask(false)
-
-            GlStateManager.tryBlendFuncSeparate(
-                GlStateManager.SourceFactor.SRC_ALPHA,
-                GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA, GlStateManager.SourceFactor.ONE,
-                GlStateManager.DestFactor.ZERO
-            )
             val width = mc.fontRenderer.getStringWidth(text) / 2
 
-            GlStateManager.disableTexture2D()
             GlStateManager.color(0f, 0f, 0f, 0.5f)
+            this.enableTranslucent()
+            GlStateManager.disableTexture2D()
             val tessellator = Tessellator.getInstance()
             val bufferBuilder = tessellator.buffer
             bufferBuilder.begin(7, DefaultVertexFormats.POSITION)
@@ -71,11 +67,8 @@ object CRenderUtils {
             GlStateManager.depthMask(true)
 
             Minecraft.getMinecraft().fontRenderer.drawString(text, -width, 0, color)
-
-            GlStateManager.depthMask(false)
-            GlStateManager.color(1f, 1f, 1f, 1f)
         }
-        restoreStates(memory)
+        this.restoreStates(memory)
         GlStateManager.popMatrix()
     }
 
@@ -84,25 +77,34 @@ object CRenderUtils {
     }
 
     fun restoreStates(states: GlStatesInformation) {
-        if (states.blend) GlStateManager.enableBlend() else GlStateManager.disableBlend()
+        GlStateManager.color(states.r, states.g, states.b, states.a)
+        GlStateManager.shadeModel(states.shadeModel)
+        GlStateManager.bindTexture(states.textureId)
         if (states.lighting) GlStateManager.enableLighting() else GlStateManager.disableLighting()
         if (states.texture2D) GlStateManager.enableTexture2D() else GlStateManager.disableTexture2D()
         if (states.alphaTest) GlStateManager.enableAlpha() else GlStateManager.disableAlpha()
         if (states.depthTest) GlStateManager.enableDepth() else GlStateManager.disableDepth()
+        if (states.depthMask) GlStateManager.depthMask(true) else GlStateManager.depthMask(false)
         if (states.cullFace) GlStateManager.enableCull() else GlStateManager.disableCull()
-
-        GlStateManager.color(states.r, states.g, states.b, states.a)
-        GlStateManager.shadeModel(states.shadeModel)
-        GlStateManager.bindTexture(states.textureId)
+        // Blend
+        if (states.blend) {
+            GlStateManager.enableBlend()
+            GlStateManager.tryBlendFuncSeparate(
+                states.blendSrc, states.blendDst,
+                states.blendSrcAlpha, states.blendDstAlpha
+            )
+        } else {
+            GlStateManager.disableBlend()
+        }
     }
 
     class GlStatesInformation(
-        val blend: Boolean = GL11.glIsEnabled(GL11.GL_BLEND),
-        val lighting: Boolean = GL11.glIsEnabled(GL11.GL_LIGHTING),
+        val lighting: Boolean = GlStateManager.lightingState.currentState,
         val texture2D: Boolean = GL11.glIsEnabled(GL11.GL_TEXTURE_2D),
-        val alphaTest: Boolean = GL11.glIsEnabled(GL11.GL_ALPHA_TEST),
-        val depthTest: Boolean = GL11.glIsEnabled(GL11.GL_DEPTH_TEST),
-        val cullFace: Boolean = GL11.glIsEnabled(GL11.GL_CULL_FACE),
+        val alphaTest: Boolean = GlStateManager.alphaState.alphaTest.currentState,
+        val depthTest: Boolean = GlStateManager.depthState.depthTest.currentState,
+        val depthMask: Boolean = GlStateManager.depthState.maskEnabled,
+        val cullFace: Boolean = GlStateManager.cullState.cullFace.currentState,
     ) {
 
         val r: Float
@@ -111,6 +113,12 @@ object CRenderUtils {
         val a: Float
         val textureId: Int
         val shadeModel: Int
+
+        val blend = GlStateManager.blendState.blend.currentState
+        val blendSrc = GlStateManager.blendState.srcFactor
+        val blendSrcAlpha = GlStateManager.blendState.srcFactorAlpha
+        val blendDst = GlStateManager.blendState.dstFactor
+        val blendDstAlpha = GlStateManager.blendState.dstFactorAlpha
 
         init {
             // Minimal size 16.

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/client/renderer/CRenderUtils.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/client/renderer/CRenderUtils.kt
@@ -1,6 +1,9 @@
 package io.github.trcdevelopers.clayium.client.renderer
 
+import net.minecraft.client.Minecraft
 import net.minecraft.client.renderer.GlStateManager
+import net.minecraft.client.renderer.Tessellator
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats
 import org.lwjgl.BufferUtils
 import org.lwjgl.opengl.GL11
 
@@ -36,6 +39,44 @@ object CRenderUtils {
         GlStateManager.enableCull()
         GlStateManager.enableLighting()
         GlStateManager.enableTexture2D()
+    }
+
+    fun renderStringWithBackground(text: String, color: Int) {
+        val mc = Minecraft.getMinecraft()
+        GlStateManager.pushMatrix()
+        val memory = memoryCurrentStates()
+        enableTranslucent()
+        run {
+            GlStateManager.glNormal3f(0.0f, 1.0f, 0.0f)
+            GlStateManager.depthMask(false)
+
+            GlStateManager.tryBlendFuncSeparate(
+                GlStateManager.SourceFactor.SRC_ALPHA,
+                GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA, GlStateManager.SourceFactor.ONE,
+                GlStateManager.DestFactor.ZERO
+            )
+            val width = mc.fontRenderer.getStringWidth(text) / 2
+
+            GlStateManager.disableTexture2D()
+            GlStateManager.color(0f, 0f, 0f, 0.5f)
+            val tessellator = Tessellator.getInstance()
+            val bufferBuilder = tessellator.buffer
+            bufferBuilder.begin(7, DefaultVertexFormats.POSITION)
+            bufferBuilder.pos(-width - 1.0, -1.0, 0.0).endVertex()
+            bufferBuilder.pos(-width - 1.0, 8.0, 0.0).endVertex()
+            bufferBuilder.pos(width + 1.0, 8.0, 0.0).endVertex()
+            bufferBuilder.pos(width + 1.0, -1.0, 0.0).endVertex()
+            tessellator.draw()
+            GlStateManager.enableTexture2D()
+            GlStateManager.depthMask(true)
+
+            Minecraft.getMinecraft().fontRenderer.drawString(text, -width, 0, color)
+
+            GlStateManager.depthMask(false)
+            GlStateManager.color(1f, 1f, 1f, 1f)
+        }
+        restoreStates(memory)
+        GlStateManager.popMatrix()
     }
 
     fun memoryCurrentStates(): GlStatesInformation {

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/client/renderer/InterfaceRenderer.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/client/renderer/InterfaceRenderer.kt
@@ -156,38 +156,13 @@ object InterfaceRenderer {
 
     private fun renderString(text: String) {
         val mc = Minecraft.getMinecraft()
+        val player = mc.player
         GlStateManager.pushMatrix()
         run {
             GlStateManager.glNormal3f(0.0f, 1.0f, 0.0f)
             GlStateManager.scale(-0.025f, -0.025f, 0.025f)
-            GlStateManager.depthMask(false)
-
-            GlStateManager.tryBlendFuncSeparate(
-                GlStateManager.SourceFactor.SRC_ALPHA,
-                GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA, GlStateManager.SourceFactor.ONE,
-                GlStateManager.DestFactor.ZERO
-            )
-            val width = mc.fontRenderer.getStringWidth(text) / 2
-
-            GlStateManager.disableTexture2D()
-            GlStateManager.color(0f, 0f, 0f, 0.5f)
-            val player = mc.player
             GlStateManager.rotate(player.rotationYaw, 0f, 1f, 0f)
-            val tessellator = Tessellator.getInstance()
-            val bufferBuilder = tessellator.buffer
-            bufferBuilder.begin(7, DefaultVertexFormats.POSITION)
-            bufferBuilder.pos(-width - 1.0, -1.0, 0.0).endVertex()
-            bufferBuilder.pos(-width - 1.0, 8.0, 0.0).endVertex()
-            bufferBuilder.pos(width + 1.0, 8.0, 0.0).endVertex()
-            bufferBuilder.pos(width + 1.0, -1.0, 0.0).endVertex()
-            tessellator.draw()
-            GlStateManager.enableTexture2D()
-            GlStateManager.depthMask(true)
-
-            Minecraft.getMinecraft().fontRenderer.drawString(text, -width, 0, 0xFFFFFF)
-
-            GlStateManager.depthMask(false)
-            GlStateManager.color(1f, 1f, 1f, 1f)
+            CRenderUtils.renderStringWithBackground(text, 0xFFFFFF)
         }
         GlStateManager.popMatrix()
     }

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/common/metatileentities/StorageContainerMetaTileEntity.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/common/metatileentities/StorageContainerMetaTileEntity.kt
@@ -359,7 +359,6 @@ class StorageContainerMetaTileEntity(
             val rayTraceResult = mc.objectMouseOver
             if (rayTraceResult.typeOfHit == RayTraceResult.Type.BLOCK && rayTraceResult.blockPos == pos) {
                 GlStateManager.pushMatrix()
-                GlStateManager.depthMask(false)
                 val itemName = stack.displayName
                 GlStateManager.rotate(180.0f, 0.0f, 1.0f, 0.0f)
                 GlStateManager.translate(0.0, 0.35, -0.55)

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/common/metatileentities/StorageContainerMetaTileEntity.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/common/metatileentities/StorageContainerMetaTileEntity.kt
@@ -357,7 +357,7 @@ class StorageContainerMetaTileEntity(
             GlStateManager.popMatrix()
             // Item Name if a player is looking at this block
             val rayTraceResult = mc.objectMouseOver
-            if (rayTraceResult.typeOfHit == RayTraceResult.Type.BLOCK && rayTraceResult.blockPos == pos) {
+            if (rayTraceResult != null && rayTraceResult.typeOfHit == RayTraceResult.Type.BLOCK && rayTraceResult.blockPos == pos) {
                 GlStateManager.pushMatrix()
                 val itemName = stack.displayName
                 GlStateManager.rotate(180.0f, 0.0f, 1.0f, 0.0f)

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/common/metatileentities/StorageContainerMetaTileEntity.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/common/metatileentities/StorageContainerMetaTileEntity.kt
@@ -20,6 +20,7 @@ import io.github.trcdevelopers.clayium.api.util.ITier
 import io.github.trcdevelopers.clayium.api.util.clayiumId
 import io.github.trcdevelopers.clayium.api.util.copyWithSize
 import io.github.trcdevelopers.clayium.client.model.ModelTextures
+import io.github.trcdevelopers.clayium.client.renderer.CRenderUtils
 import io.github.trcdevelopers.clayium.common.items.metaitem.MetaItemClayParts
 import io.github.trcdevelopers.clayium.common.util.CNumberFormat
 import io.github.trcdevelopers.clayium.common.util.transferTo
@@ -42,6 +43,7 @@ import net.minecraft.util.EnumFacing
 import net.minecraft.util.EnumHand
 import net.minecraft.util.ResourceLocation
 import net.minecraft.util.math.BlockPos
+import net.minecraft.util.math.RayTraceResult
 import net.minecraft.world.World
 import net.minecraftforge.client.model.ModelLoader
 import net.minecraftforge.common.capabilities.Capability
@@ -344,6 +346,7 @@ class StorageContainerMetaTileEntity(
                 else -> {}
             }
 
+            // Item Amount
             GlStateManager.pushMatrix()
             val amountText: String = numberFormatter.format(itemsStored.toDouble())
             val fRenderer = mc.fontRenderer
@@ -352,6 +355,21 @@ class StorageContainerMetaTileEntity(
             GlStateManager.scale(-0.025f, -0.025f, 0.025f)
             fRenderer.drawString(amountText, -fRenderer.getStringWidth(amountText) / 2, 0, 0)
             GlStateManager.popMatrix()
+            // Item Name if a player is looking at this block
+            val rayTraceResult = mc.objectMouseOver
+            if (rayTraceResult.typeOfHit == RayTraceResult.Type.BLOCK && rayTraceResult.blockPos == pos) {
+                GlStateManager.pushMatrix()
+                GlStateManager.depthMask(false)
+                val itemName = stack.displayName
+                GlStateManager.rotate(180.0f, 0.0f, 1.0f, 0.0f)
+                GlStateManager.translate(0.0, 0.35, -0.55)
+                GlStateManager.scale(-0.025f, -0.025f, 0.025f)
+                GlStateManager.scale(0.5, 0.5, 0.5)
+
+                CRenderUtils.renderStringWithBackground(itemName, -1)
+
+                GlStateManager.popMatrix()
+            }
         }
         GlStateManager.popMatrix()
     }


### PR DESCRIPTION
## What
原作では、Storage Containerにカーソルを合わせると保存しているアイテムの名前が表示されていた。
この機能を追加する。


## Additional Information
`CRenderUtils.memoryCurrentStates/restoreStates`がさらに多くのGl Statesを保存/読込できるよう、実装を少し追加や変更した。