### PR TITLE
Refactor Rendering

### DIFF
--- a/src/main/kotlin/io/github/trcdevelopers/clayium/client/renderer/AreaMarkerRenderer.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/client/renderer/AreaMarkerRenderer.kt
@@ -18,6 +18,8 @@ object AreaMarkerRenderer {
 
     private fun renderSourceOverlay(source: Cuboid6) {
         GlStateManager.pushMatrix()
+        val states = CRenderUtils.memoryCurrentStates()
+        GlStateManager.disableTexture2D()
         CRenderUtils.enableTranslucent()
         CRenderUtils.enableXray()
         run {
@@ -26,13 +28,14 @@ object AreaMarkerRenderer {
             GlStateManager.color(0.7f, 0.1f, 0.1f, 1f)
             RenderUtils.drawCuboidOutline(source)
         }
-        CRenderUtils.disableXray()
-        CRenderUtils.disableTranslucent()
+        CRenderUtils.restoreStates(states)
         GlStateManager.popMatrix()
     }
 
     private fun renderRangeOverlay(range: Cuboid6, xray: Boolean) {
         GlStateManager.pushMatrix()
+        val states = CRenderUtils.memoryCurrentStates()
+        GlStateManager.disableTexture2D()
         CRenderUtils.enableTranslucent()
         if (xray) { CRenderUtils.enableXray() }
         run {
@@ -41,8 +44,7 @@ object AreaMarkerRenderer {
             GlStateManager.color(0.1f, 0.1f, 0.7f, 1f)
             RenderUtils.drawCuboidOutline(range)
         }
-        if (xray) { CRenderUtils.disableXray() }
-        CRenderUtils.disableTranslucent()
+        CRenderUtils.restoreStates(states)
         GlStateManager.popMatrix()
     }
 

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/client/renderer/AreaMarkerRenderer.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/client/renderer/AreaMarkerRenderer.kt
@@ -1,6 +1,7 @@
 package io.github.trcdevelopers.clayium.client.renderer
 
 import codechicken.lib.render.RenderUtils
+import codechicken.lib.render.state.GlStateTracker
 import codechicken.lib.vec.Cuboid6
 import net.minecraft.client.renderer.GlStateManager
 
@@ -18,7 +19,7 @@ object AreaMarkerRenderer {
 
     private fun renderSourceOverlay(source: Cuboid6) {
         GlStateManager.pushMatrix()
-        val states = CRenderUtils.memoryCurrentStates()
+        GlStateTracker.pushState()
         GlStateManager.disableTexture2D()
         CRenderUtils.enableTranslucent()
         CRenderUtils.enableXray()
@@ -28,13 +29,14 @@ object AreaMarkerRenderer {
             GlStateManager.color(0.7f, 0.1f, 0.1f, 1f)
             RenderUtils.drawCuboidOutline(source)
         }
-        CRenderUtils.restoreStates(states)
+        GlStateTracker.popState()
+        GlStateManager.enableTexture2D()
         GlStateManager.popMatrix()
     }
 
     private fun renderRangeOverlay(range: Cuboid6, xray: Boolean) {
         GlStateManager.pushMatrix()
-        val states = CRenderUtils.memoryCurrentStates()
+        GlStateTracker.pushState()
         GlStateManager.disableTexture2D()
         CRenderUtils.enableTranslucent()
         if (xray) { CRenderUtils.enableXray() }
@@ -44,7 +46,8 @@ object AreaMarkerRenderer {
             GlStateManager.color(0.1f, 0.1f, 0.7f, 1f)
             RenderUtils.drawCuboidOutline(range)
         }
-        CRenderUtils.restoreStates(states)
+        GlStateTracker.popState()
+        GlStateManager.enableTexture2D()
         GlStateManager.popMatrix()
     }
 

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/client/renderer/CRenderUtils.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/client/renderer/CRenderUtils.kt
@@ -10,7 +10,7 @@ import org.lwjgl.opengl.GL11
 
 object CRenderUtils {
     /**
-     * Disables: lightning, depthMask.
+     * Disables: lighting, depthMask.
      * Enables: blend, depth, blendFunc.
      *
      * You can use [codechicken.lib.render.state.GlStateTracker] to push/pop GL states around this call.
@@ -28,7 +28,7 @@ object CRenderUtils {
     }
 
     /**
-     * Disables: texture2D, lightning, cullFace, depth.
+     * Disables: texture2D, lighting, cullFace, depth.
      *
      * You can use [codechicken.lib.render.state.GlStateTracker] to push/pop GL states around this call.
      * NOTE: Texture2D is NOT TRACKED by GlStateTracker, REMEMBER to enable it back.

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/client/renderer/CRenderUtils.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/client/renderer/CRenderUtils.kt
@@ -5,6 +5,11 @@ import org.lwjgl.BufferUtils
 import org.lwjgl.opengl.GL11
 
 object CRenderUtils {
+    /**
+     * Disables Lightning, depthMask.
+     * Enables Blend, Depth, and BlendFunc
+     * Make sure to store current OpenGL state by calling [CrenderUtils.memoryCurrentStates].
+     */
     fun enableTranslucent() {
         GlStateManager.disableLighting()
         GlStateManager.enableBlend()
@@ -14,13 +19,11 @@ object CRenderUtils {
         )
         GlStateManager.enableDepth()
         GlStateManager.depthMask(false)
-
-        GlStateManager.disableTexture2D()
     }
 
+    @Deprecated("Use memoryCurrentStates and restoreStates instead.")
     fun disableTranslucent() {
         GlStateManager.disableBlend()
-        GlStateManager.enableTexture2D()
         GlStateManager.depthMask(true)
         GlStateManager.enableDepth()
     }

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/client/renderer/CRenderUtils.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/client/renderer/CRenderUtils.kt
@@ -8,7 +8,7 @@ object CRenderUtils {
     /**
      * Disables Lightning, depthMask.
      * Enables Blend, Depth, and BlendFunc
-     * Make sure to store current OpenGL state by calling [CrenderUtils.memoryCurrentStates].
+     * Make sure to store current OpenGL state by calling [CRenderUtils.memoryCurrentStates].
      */
     fun enableTranslucent() {
         GlStateManager.disableLighting()

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/client/renderer/CRenderUtils.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/client/renderer/CRenderUtils.kt
@@ -21,25 +21,11 @@ object CRenderUtils {
         GlStateManager.depthMask(false)
     }
 
-    @Deprecated("Use memoryCurrentStates and restoreStates instead.")
-    fun disableTranslucent() {
-        GlStateManager.disableBlend()
-        GlStateManager.depthMask(true)
-        GlStateManager.enableDepth()
-    }
-
     fun enableXray() {
         GlStateManager.disableTexture2D()
         GlStateManager.disableLighting()
         GlStateManager.disableCull()
         GlStateManager.disableDepth()
-    }
-
-    fun disableXray() {
-        GlStateManager.enableDepth()
-        GlStateManager.enableCull()
-        GlStateManager.enableLighting()
-        GlStateManager.enableTexture2D()
     }
 
     fun memoryCurrentStates(): GlStatesInformation {

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/client/renderer/CRenderUtils.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/client/renderer/CRenderUtils.kt
@@ -5,6 +5,8 @@ import net.minecraft.client.Minecraft
 import net.minecraft.client.renderer.GlStateManager
 import net.minecraft.client.renderer.Tessellator
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats
+import net.minecraft.util.math.AxisAlignedBB
+import org.lwjgl.opengl.GL11
 
 object CRenderUtils {
     /**
@@ -67,5 +69,36 @@ object CRenderUtils {
         }
         GlStateTracker.popState()
         GlStateManager.popMatrix()
+    }
+
+    fun renderCube(aabb: AxisAlignedBB, r: Float, g: Float, b: Float, a: Float) {
+        val tessellator = Tessellator.getInstance()
+        val bufferBuilder = tessellator.buffer
+        bufferBuilder.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_COLOR)
+        bufferBuilder.pos(aabb.minX, aabb.maxY, aabb.minZ).color(r, g, b, a).endVertex()
+        bufferBuilder.pos(aabb.maxX, aabb.maxY, aabb.minZ).color(r, g, b, a).endVertex()
+        bufferBuilder.pos(aabb.maxX, aabb.minY, aabb.minZ).color(r, g, b, a).endVertex()
+        bufferBuilder.pos(aabb.minX, aabb.minY, aabb.minZ).color(r, g, b, a).endVertex()
+        bufferBuilder.pos(aabb.minX, aabb.minY, aabb.maxZ).color(r, g, b, a).endVertex()
+        bufferBuilder.pos(aabb.maxX, aabb.minY, aabb.maxZ).color(r, g, b, a).endVertex()
+        bufferBuilder.pos(aabb.maxX, aabb.maxY, aabb.maxZ).color(r, g, b, a).endVertex()
+        bufferBuilder.pos(aabb.minX, aabb.maxY, aabb.maxZ).color(r, g, b, a).endVertex()
+        bufferBuilder.pos(aabb.minX, aabb.minY, aabb.minZ).color(r, g, b, a).endVertex()
+        bufferBuilder.pos(aabb.maxX, aabb.minY, aabb.minZ).color(r, g, b, a).endVertex()
+        bufferBuilder.pos(aabb.maxX, aabb.minY, aabb.maxZ).color(r, g, b, a).endVertex()
+        bufferBuilder.pos(aabb.minX, aabb.minY, aabb.maxZ).color(r, g, b, a).endVertex()
+        bufferBuilder.pos(aabb.minX, aabb.maxY, aabb.maxZ).color(r, g, b, a).endVertex()
+        bufferBuilder.pos(aabb.maxX, aabb.maxY, aabb.maxZ).color(r, g, b, a).endVertex()
+        bufferBuilder.pos(aabb.maxX, aabb.maxY, aabb.minZ).color(r, g, b, a).endVertex()
+        bufferBuilder.pos(aabb.minX, aabb.maxY, aabb.minZ).color(r, g, b, a).endVertex()
+        bufferBuilder.pos(aabb.minX, aabb.minY, aabb.maxZ).color(r, g, b, a).endVertex()
+        bufferBuilder.pos(aabb.minX, aabb.maxY, aabb.maxZ).color(r, g, b, a).endVertex()
+        bufferBuilder.pos(aabb.minX, aabb.maxY, aabb.minZ).color(r, g, b, a).endVertex()
+        bufferBuilder.pos(aabb.minX, aabb.minY, aabb.minZ).color(r, g, b, a).endVertex()
+        bufferBuilder.pos(aabb.maxX, aabb.minY, aabb.minZ).color(r, g, b, a).endVertex()
+        bufferBuilder.pos(aabb.maxX, aabb.maxY, aabb.minZ).color(r, g, b, a).endVertex()
+        bufferBuilder.pos(aabb.maxX, aabb.maxY, aabb.maxZ).color(r, g, b, a).endVertex()
+        bufferBuilder.pos(aabb.maxX, aabb.minY, aabb.maxZ).color(r, g, b, a).endVertex()
+        tessellator.draw()
     }
 }

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/client/renderer/CRenderUtils.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/client/renderer/CRenderUtils.kt
@@ -28,13 +28,12 @@ object CRenderUtils {
     }
 
     /**
-     * Disables: texture2D, lighting, cullFace, depth.
+     * Disables: lighting, cullFace, depth.
      *
      * You can use [codechicken.lib.render.state.GlStateTracker] to push/pop GL states around this call.
-     * NOTE: Texture2D is NOT TRACKED by GlStateTracker, REMEMBER to enable it back.
+     * All the states modified by this method are tracked by GlStateTracker.
      */
     fun enableXray() {
-        GlStateManager.disableTexture2D()
         GlStateManager.disableLighting()
         GlStateManager.disableCull()
         GlStateManager.disableDepth()

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/client/renderer/CRenderUtils.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/client/renderer/CRenderUtils.kt
@@ -75,26 +75,32 @@ object CRenderUtils {
         val tessellator = Tessellator.getInstance()
         val bufferBuilder = tessellator.buffer
         bufferBuilder.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_COLOR)
+
         bufferBuilder.pos(aabb.minX, aabb.maxY, aabb.minZ).color(r, g, b, a).endVertex()
         bufferBuilder.pos(aabb.maxX, aabb.maxY, aabb.minZ).color(r, g, b, a).endVertex()
         bufferBuilder.pos(aabb.maxX, aabb.minY, aabb.minZ).color(r, g, b, a).endVertex()
         bufferBuilder.pos(aabb.minX, aabb.minY, aabb.minZ).color(r, g, b, a).endVertex()
+
         bufferBuilder.pos(aabb.minX, aabb.minY, aabb.maxZ).color(r, g, b, a).endVertex()
         bufferBuilder.pos(aabb.maxX, aabb.minY, aabb.maxZ).color(r, g, b, a).endVertex()
         bufferBuilder.pos(aabb.maxX, aabb.maxY, aabb.maxZ).color(r, g, b, a).endVertex()
         bufferBuilder.pos(aabb.minX, aabb.maxY, aabb.maxZ).color(r, g, b, a).endVertex()
+
         bufferBuilder.pos(aabb.minX, aabb.minY, aabb.minZ).color(r, g, b, a).endVertex()
         bufferBuilder.pos(aabb.maxX, aabb.minY, aabb.minZ).color(r, g, b, a).endVertex()
         bufferBuilder.pos(aabb.maxX, aabb.minY, aabb.maxZ).color(r, g, b, a).endVertex()
         bufferBuilder.pos(aabb.minX, aabb.minY, aabb.maxZ).color(r, g, b, a).endVertex()
+
         bufferBuilder.pos(aabb.minX, aabb.maxY, aabb.maxZ).color(r, g, b, a).endVertex()
         bufferBuilder.pos(aabb.maxX, aabb.maxY, aabb.maxZ).color(r, g, b, a).endVertex()
         bufferBuilder.pos(aabb.maxX, aabb.maxY, aabb.minZ).color(r, g, b, a).endVertex()
         bufferBuilder.pos(aabb.minX, aabb.maxY, aabb.minZ).color(r, g, b, a).endVertex()
+
         bufferBuilder.pos(aabb.minX, aabb.minY, aabb.maxZ).color(r, g, b, a).endVertex()
         bufferBuilder.pos(aabb.minX, aabb.maxY, aabb.maxZ).color(r, g, b, a).endVertex()
         bufferBuilder.pos(aabb.minX, aabb.maxY, aabb.minZ).color(r, g, b, a).endVertex()
         bufferBuilder.pos(aabb.minX, aabb.minY, aabb.minZ).color(r, g, b, a).endVertex()
+
         bufferBuilder.pos(aabb.maxX, aabb.minY, aabb.minZ).color(r, g, b, a).endVertex()
         bufferBuilder.pos(aabb.maxX, aabb.maxY, aabb.minZ).color(r, g, b, a).endVertex()
         bufferBuilder.pos(aabb.maxX, aabb.maxY, aabb.maxZ).color(r, g, b, a).endVertex()

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/client/renderer/CRenderUtils.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/client/renderer/CRenderUtils.kt
@@ -1,17 +1,18 @@
 package io.github.trcdevelopers.clayium.client.renderer
 
+import codechicken.lib.render.state.GlStateTracker
 import net.minecraft.client.Minecraft
 import net.minecraft.client.renderer.GlStateManager
 import net.minecraft.client.renderer.Tessellator
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats
-import org.lwjgl.BufferUtils
-import org.lwjgl.opengl.GL11
 
 object CRenderUtils {
     /**
-     * Disables Lightning, depthMask.
-     * Enables Blend, Depth, and BlendFunc
-     * Make sure to store current OpenGL state by calling [CRenderUtils.memoryCurrentStates].
+     * Disables: lightning, depthMask.
+     * Enables: blend, depth, blendFunc.
+     *
+     * You can use [codechicken.lib.render.state.GlStateTracker] to push/pop GL states around this call.
+     * All the states modified by this method are tracked by GlStateTracker.
      */
     fun enableTranslucent() {
         GlStateManager.disableLighting()
@@ -24,6 +25,12 @@ object CRenderUtils {
         GlStateManager.depthMask(false)
     }
 
+    /**
+     * Disables: texture2D, lightning, cullFace, depth.
+     *
+     * You can use [codechicken.lib.render.state.GlStateTracker] to push/pop GL states around this call.
+     * NOTE: Texture2D is NOT TRACKED by GlStateTracker, REMEMBER to enable it back.
+     */
     fun enableXray() {
         GlStateManager.disableTexture2D()
         GlStateManager.disableLighting()
@@ -32,19 +39,19 @@ object CRenderUtils {
     }
 
     /**
-     * Draws given text with given color and a semi-transparent black background at a current scale/position.
+     * Draws given text with given colour and a semi-transparent black background at a current scale/position.
      */
     fun renderStringWithBackground(text: String, color: Int) {
         val mc = Minecraft.getMinecraft()
         GlStateManager.pushMatrix()
-        val memory = memoryCurrentStates()
+        GlStateTracker.pushState()
+        GlStateManager.glNormal3f(0.0f, 1.0f, 0.0f)
+        GlStateManager.color(0f, 0f, 0f, 0.5f)
+        GlStateManager.disableTexture2D()
+        this.enableTranslucent()
         run {
-            GlStateManager.glNormal3f(0.0f, 1.0f, 0.0f)
-            val width = mc.fontRenderer.getStringWidth(text) / 2
 
-            GlStateManager.color(0f, 0f, 0f, 0.5f)
-            this.enableTranslucent()
-            GlStateManager.disableTexture2D()
+            val width = mc.fontRenderer.getStringWidth(text) / 2
             val tessellator = Tessellator.getInstance()
             val bufferBuilder = tessellator.buffer
             bufferBuilder.begin(7, DefaultVertexFormats.POSITION)
@@ -53,77 +60,12 @@ object CRenderUtils {
             bufferBuilder.pos(width + 1.0, 8.0, 0.0).endVertex()
             bufferBuilder.pos(width + 1.0, -1.0, 0.0).endVertex()
             tessellator.draw()
+
             GlStateManager.enableTexture2D()
             GlStateManager.depthMask(true)
-
             Minecraft.getMinecraft().fontRenderer.drawString(text, -width, 0, color)
         }
-        this.restoreStates(memory)
+        GlStateTracker.popState()
         GlStateManager.popMatrix()
-    }
-
-    fun memoryCurrentStates(): GlStatesInformation {
-        return GlStatesInformation()
-    }
-
-    fun restoreStates(states: GlStatesInformation) {
-        GlStateManager.color(states.r, states.g, states.b, states.a)
-        GlStateManager.shadeModel(states.shadeModel)
-        GlStateManager.bindTexture(states.textureId)
-        if (states.lighting) GlStateManager.enableLighting() else GlStateManager.disableLighting()
-        if (states.texture2D) GlStateManager.enableTexture2D() else GlStateManager.disableTexture2D()
-        if (states.alphaTest) GlStateManager.enableAlpha() else GlStateManager.disableAlpha()
-        if (states.depthTest) GlStateManager.enableDepth() else GlStateManager.disableDepth()
-        if (states.depthMask) GlStateManager.depthMask(true) else GlStateManager.depthMask(false)
-        if (states.cullFace) GlStateManager.enableCull() else GlStateManager.disableCull()
-        // Blend
-        if (states.blend) {
-            GlStateManager.enableBlend()
-            GlStateManager.tryBlendFuncSeparate(
-                states.blendSrc, states.blendDst,
-                states.blendSrcAlpha, states.blendDstAlpha
-            )
-        } else {
-            GlStateManager.disableBlend()
-        }
-    }
-
-    class GlStatesInformation(
-        val lighting: Boolean = GlStateManager.lightingState.currentState,
-        val texture2D: Boolean = GL11.glIsEnabled(GL11.GL_TEXTURE_2D),
-        val alphaTest: Boolean = GlStateManager.alphaState.alphaTest.currentState,
-        val depthTest: Boolean = GlStateManager.depthState.depthTest.currentState,
-        val depthMask: Boolean = GlStateManager.depthState.maskEnabled,
-        val cullFace: Boolean = GlStateManager.cullState.cullFace.currentState,
-    ) {
-
-        val r: Float
-        val g: Float
-        val b: Float
-        val a: Float
-        val textureId: Int
-        val shadeModel: Int
-
-        val blend = GlStateManager.blendState.blend.currentState
-        val blendSrc = GlStateManager.blendState.srcFactor
-        val blendSrcAlpha = GlStateManager.blendState.srcFactorAlpha
-        val blendDst = GlStateManager.blendState.dstFactor
-        val blendDstAlpha = GlStateManager.blendState.dstFactorAlpha
-
-        init {
-            // Minimal size 16.
-            // java.lang.IllegalArgumentException: Number of remaining buffer elements is 4, must be at least 16.
-            // Because at most 16 elements can be returned, a buffer with at least 16 elements is required, regardless of actual returned element count
-            val rgba = BufferUtils.createFloatBuffer(16)
-            GL11.glGetFloat(GL11.GL_CURRENT_COLOR, rgba)
-            r = rgba[0]
-            g = rgba[1]
-            b = rgba[2]
-            a = rgba[3]
-
-            // Use non-buffer version, because buffer version is shifted by 8 bits.
-            this.textureId = GL11.glGetInteger(GL11.GL_TEXTURE_BINDING_2D)
-            this.shadeModel = GL11.glGetInteger(GL11.GL_SHADE_MODEL)
-        }
     }
 }

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/client/renderer/CRenderUtils.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/client/renderer/CRenderUtils.kt
@@ -19,6 +19,7 @@ object CRenderUtils {
     }
 
     fun disableTranslucent() {
+        GlStateManager.disableBlend()
         GlStateManager.enableTexture2D()
         GlStateManager.depthMask(true)
         GlStateManager.enableDepth()

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/client/renderer/item/ItemDamagedRenderer.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/client/renderer/item/ItemDamagedRenderer.kt
@@ -1,10 +1,10 @@
 package io.github.trcdevelopers.clayium.client.renderer.item
 
 import codechicken.lib.render.item.IItemRenderer
+import codechicken.lib.render.state.GlStateTracker
 import codechicken.lib.util.TransformUtils
 import io.github.trcdevelopers.clayium.api.util.CLog
 import io.github.trcdevelopers.clayium.api.util.clayiumId
-import io.github.trcdevelopers.clayium.client.renderer.CRenderUtils
 import it.unimi.dsi.fastutil.shorts.Short2ObjectMap
 import it.unimi.dsi.fastutil.shorts.Short2ObjectOpenHashMap
 import net.minecraft.client.Minecraft
@@ -79,7 +79,6 @@ class ItemDamagedRenderer(
     }
 
     override fun renderItem(stack: ItemStack, transformType: ItemCameraTransforms.TransformType) {
-
         val meta = stack.metadata.toShort()
         val models = models.get(meta)
         if (models == null || models.size != 3) {
@@ -92,9 +91,8 @@ class ItemDamagedRenderer(
         val tessellator = Tessellator.getInstance()
         val buf = tessellator.buffer
 
-        mc.textureManager.bindTexture(TextureMap.LOCATION_BLOCKS_TEXTURE)
-        mc.textureManager.getTexture(TextureMap.LOCATION_BLOCKS_TEXTURE).setBlurMipmap(false, false)
-        val states = CRenderUtils.memoryCurrentStates()
+        GlStateManager.pushMatrix()
+        GlStateTracker.pushState()
         GlStateManager.color(1.0f, 1.0f, 1.0f, 1.0f)
         GlStateManager.enableRescaleNormal()
         GlStateManager.alphaFunc(GL11.GL_GREATER, 0.1f)
@@ -102,55 +100,53 @@ class ItemDamagedRenderer(
             GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA,
             GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ZERO
         )
-
         if (transformType == ItemCameraTransforms.TransformType.GUI) {
             GlStateManager.disableLighting()
         }
+        run {
+            mc.textureManager.bindTexture(TextureMap.LOCATION_BLOCKS_TEXTURE)
+            mc.textureManager.getTexture(TextureMap.LOCATION_BLOCKS_TEXTURE).setBlurMipmap(false, false)
 
-        GlStateManager.pushMatrix()
+            // L0
+            buf.begin(GL11.GL_QUADS, DefaultVertexFormats.ITEM)
+            renderModelQuads(buf, modelL0.getQuads(null, null, 0L), stack, 0)
+            for (facing in EnumFacing.entries) {
+                renderModelQuads(buf, modelL0.getQuads(null, facing, 0L), stack, 0)
+            }
+            tessellator.draw()
 
-        // L0
-        buf.begin(GL11.GL_QUADS, DefaultVertexFormats.ITEM)
-        renderModelQuads(buf, modelL0.getQuads(null, null, 0L), stack, 0)
-        for (facing in EnumFacing.entries) {
-            renderModelQuads(buf, modelL0.getQuads(null, facing, 0L), stack, 0)
+            if (doPolygonOffset) {
+                GlStateManager.enablePolygonOffset()
+                GlStateManager.doPolygonOffset(-0.01f, -0.1f)
+            }
+
+            // L1,L2
+            buf.begin(GL11.GL_QUADS, DefaultVertexFormats.ITEM)
+            renderModelQuads(buf, modelL1.getQuads(null, null, 0L), stack, 1)
+            for (facing in EnumFacing.entries) {
+                renderModelQuads(buf, modelL1.getQuads(null, facing, 0L), stack, 1)
+            }
+            tessellator.draw()
+
+            if (doPolygonOffset) {
+                GlStateManager.doPolygonOffset(-0.02f, -0.2f)
+            }
+
+            buf.begin(GL11.GL_QUADS, DefaultVertexFormats.ITEM)
+            renderModelQuads(buf, modelL2.getQuads(null, null, 0L), stack, 2)
+            for (facing in EnumFacing.entries) {
+                renderModelQuads(buf, modelL2.getQuads(null, facing, 0L), stack, 2)
+            }
+
+            tessellator.draw()
+
+            if (doPolygonOffset) {
+                GlStateManager.disablePolygonOffset()
+            }
         }
-        tessellator.draw()
-
-        if (doPolygonOffset) {
-            GlStateManager.enablePolygonOffset()
-            GlStateManager.doPolygonOffset(-0.01f, -0.1f)
-        }
-
-        // L1,L2
-        buf.begin(GL11.GL_QUADS, DefaultVertexFormats.ITEM)
-        renderModelQuads(buf, modelL1.getQuads(null, null, 0L), stack, 1)
-        for (facing in EnumFacing.entries) {
-            renderModelQuads(buf, modelL1.getQuads(null, facing, 0L), stack, 1)
-        }
-        tessellator.draw()
-
-        if (doPolygonOffset) {
-            GlStateManager.doPolygonOffset(-0.02f, -0.2f)
-        }
-
-        buf.begin(GL11.GL_QUADS, DefaultVertexFormats.ITEM)
-        renderModelQuads(buf, modelL2.getQuads(null, null, 0L), stack, 2)
-        for (facing in EnumFacing.entries) {
-            renderModelQuads(buf, modelL2.getQuads(null, facing, 0L), stack, 2)
-        }
-
-        tessellator.draw()
-
-        if (doPolygonOffset) {
-            GlStateManager.disablePolygonOffset()
-        }
-
-        GlStateManager.cullFace(GlStateManager.CullFace.BACK)
+        GlStateTracker.popState()
         GlStateManager.popMatrix()
 
-        GlStateManager.disableRescaleNormal()
-        CRenderUtils.restoreStates(states)
         mc.textureManager.bindTexture(TextureMap.LOCATION_BLOCKS_TEXTURE)
         mc.textureManager.getTexture(TextureMap.LOCATION_BLOCKS_TEXTURE).restoreLastBlurMipmap()
     }

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/common/metatileentities/multiblock/CaReactorMetaTileEntity.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/common/metatileentities/multiblock/CaReactorMetaTileEntity.kt
@@ -1,5 +1,6 @@
 package io.github.trcdevelopers.clayium.common.metatileentities.multiblock
 
+import codechicken.lib.render.state.GlStateTracker
 import com.cleanroommc.modularui.api.drawable.IKey
 import com.cleanroommc.modularui.drawable.GuiTextures
 import com.cleanroommc.modularui.utils.Alignment
@@ -264,7 +265,7 @@ class CaReactorMetaTileEntity(
                 val aabb = AxisAlignedBB(pos.x - d, pos.y - d, pos.z - d, pos.x + s + d, pos.y + s + d, pos.z + s + d)
 
                 GlStateManager.pushMatrix()
-                val states = CRenderUtils.memoryCurrentStates()
+                GlStateTracker.pushState()
                 GlStateManager.disableTexture2D()
                 CRenderUtils.enableTranslucent()
 
@@ -302,7 +303,8 @@ class CaReactorMetaTileEntity(
                 bufferBuilder.pos(aabb.maxX, aabb.minY, aabb.maxZ).color(r, g, b, a).endVertex()
                 tessellator.draw()
 
-                CRenderUtils.restoreStates(states)
+                GlStateManager.enableTexture2D()
+                GlStateTracker.popState()
                 GlStateManager.popMatrix()
             }
         }

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/common/metatileentities/multiblock/CaReactorMetaTileEntity.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/common/metatileentities/multiblock/CaReactorMetaTileEntity.kt
@@ -264,6 +264,8 @@ class CaReactorMetaTileEntity(
                 val aabb = AxisAlignedBB(pos.x - d, pos.y - d, pos.z - d, pos.x + s + d, pos.y + s + d, pos.z + s + d)
 
                 GlStateManager.pushMatrix()
+                val states = CRenderUtils.memoryCurrentStates()
+                GlStateManager.disableTexture2D()
                 CRenderUtils.enableTranslucent()
 
                 GlStateManager.translate(x, y, z)
@@ -299,9 +301,8 @@ class CaReactorMetaTileEntity(
                 bufferBuilder.pos(aabb.maxX, aabb.maxY, aabb.maxZ).color(r, g, b, a).endVertex()
                 bufferBuilder.pos(aabb.maxX, aabb.minY, aabb.maxZ).color(r, g, b, a).endVertex()
                 tessellator.draw()
-                GlStateManager.color(1f, 1f, 1f, 1f)
 
-                CRenderUtils.disableTranslucent()
+                CRenderUtils.restoreStates(states)
                 GlStateManager.popMatrix()
             }
         }

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/common/metatileentities/multiblock/CaReactorMetaTileEntity.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/common/metatileentities/multiblock/CaReactorMetaTileEntity.kt
@@ -35,8 +35,6 @@ import io.github.trcdevelopers.clayium.common.recipe.registry.CaReactorRecipeReg
 import io.github.trcdevelopers.clayium.common.util.SidelessI18n
 import it.unimi.dsi.fastutil.ints.IntArrayList
 import net.minecraft.client.renderer.GlStateManager
-import net.minecraft.client.renderer.Tessellator
-import net.minecraft.client.renderer.vertex.DefaultVertexFormats
 import net.minecraft.client.resources.I18n
 import net.minecraft.network.PacketBuffer
 import net.minecraft.util.EnumFacing
@@ -45,7 +43,6 @@ import net.minecraft.util.math.AxisAlignedBB
 import net.minecraft.util.math.BlockPos
 import net.minecraft.util.text.ITextComponent
 import net.minecraft.util.text.TextComponentTranslation
-import org.lwjgl.opengl.GL11
 import kotlin.math.pow
 
 class CaReactorMetaTileEntity(
@@ -251,6 +248,12 @@ class CaReactorMetaTileEntity(
 
     override fun renderMetaTileEntity(x: Double, y: Double, z: Double, partialTicks: Float) {
         if (!(this.workable.isWorking && ConfigCore.rendering.caReactorGlittering)) return
+        GlStateManager.pushMatrix()
+        GlStateTracker.pushState()
+        GlStateManager.disableTexture2D()
+        CRenderUtils.enableTranslucent()
+
+        GlStateManager.translate(x, y, z)
         for (j in 1..<(avgHullRank + 2)) {
             for (hullPos in hullPoses) {
                 val pos = hullPos.subtract(this.pos ?: return)
@@ -259,55 +262,18 @@ class CaReactorMetaTileEntity(
                 val k = j / (avgHullRank + 1.0)
                 val d = 0.01f * (i.pow(1.6) + 1.0)
 
-                val tessellator = Tessellator.getInstance()
-                val bufferBuilder = tessellator.buffer
-
                 val aabb = AxisAlignedBB(pos.x - d, pos.y - d, pos.z - d, pos.x + s + d, pos.y + s + d, pos.z + s + d)
-
-                GlStateManager.pushMatrix()
-                GlStateTracker.pushState()
-                GlStateManager.disableTexture2D()
-                CRenderUtils.enableTranslucent()
-
-                GlStateManager.translate(x, y, z)
-
                 val r = 1f
                 val g = 1f
                 val b = (0.3f + 0.05f + (2.0f * k - k * k) * j).toFloat()
                 val a = 0.11f
-
-                bufferBuilder.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_COLOR)
-                bufferBuilder.pos(aabb.minX, aabb.maxY, aabb.minZ).color(r, g, b, a).endVertex()
-                bufferBuilder.pos(aabb.maxX, aabb.maxY, aabb.minZ).color(r, g, b, a).endVertex()
-                bufferBuilder.pos(aabb.maxX, aabb.minY, aabb.minZ).color(r, g, b, a).endVertex()
-                bufferBuilder.pos(aabb.minX, aabb.minY, aabb.minZ).color(r, g, b, a).endVertex()
-                bufferBuilder.pos(aabb.minX, aabb.minY, aabb.maxZ).color(r, g, b, a).endVertex()
-                bufferBuilder.pos(aabb.maxX, aabb.minY, aabb.maxZ).color(r, g, b, a).endVertex()
-                bufferBuilder.pos(aabb.maxX, aabb.maxY, aabb.maxZ).color(r, g, b, a).endVertex()
-                bufferBuilder.pos(aabb.minX, aabb.maxY, aabb.maxZ).color(r, g, b, a).endVertex()
-                bufferBuilder.pos(aabb.minX, aabb.minY, aabb.minZ).color(r, g, b, a).endVertex()
-                bufferBuilder.pos(aabb.maxX, aabb.minY, aabb.minZ).color(r, g, b, a).endVertex()
-                bufferBuilder.pos(aabb.maxX, aabb.minY, aabb.maxZ).color(r, g, b, a).endVertex()
-                bufferBuilder.pos(aabb.minX, aabb.minY, aabb.maxZ).color(r, g, b, a).endVertex()
-                bufferBuilder.pos(aabb.minX, aabb.maxY, aabb.maxZ).color(r, g, b, a).endVertex()
-                bufferBuilder.pos(aabb.maxX, aabb.maxY, aabb.maxZ).color(r, g, b, a).endVertex()
-                bufferBuilder.pos(aabb.maxX, aabb.maxY, aabb.minZ).color(r, g, b, a).endVertex()
-                bufferBuilder.pos(aabb.minX, aabb.maxY, aabb.minZ).color(r, g, b, a).endVertex()
-                bufferBuilder.pos(aabb.minX, aabb.minY, aabb.maxZ).color(r, g, b, a).endVertex()
-                bufferBuilder.pos(aabb.minX, aabb.maxY, aabb.maxZ).color(r, g, b, a).endVertex()
-                bufferBuilder.pos(aabb.minX, aabb.maxY, aabb.minZ).color(r, g, b, a).endVertex()
-                bufferBuilder.pos(aabb.minX, aabb.minY, aabb.minZ).color(r, g, b, a).endVertex()
-                bufferBuilder.pos(aabb.maxX, aabb.minY, aabb.minZ).color(r, g, b, a).endVertex()
-                bufferBuilder.pos(aabb.maxX, aabb.maxY, aabb.minZ).color(r, g, b, a).endVertex()
-                bufferBuilder.pos(aabb.maxX, aabb.maxY, aabb.maxZ).color(r, g, b, a).endVertex()
-                bufferBuilder.pos(aabb.maxX, aabb.minY, aabb.maxZ).color(r, g, b, a).endVertex()
-                tessellator.draw()
-
-                GlStateManager.enableTexture2D()
-                GlStateTracker.popState()
-                GlStateManager.popMatrix()
+                CRenderUtils.renderCube(aabb, r, g, b, a)
             }
         }
+        GlStateManager.color(1f, 1f, 1f, 1f)
+        GlStateManager.enableTexture2D()
+        GlStateTracker.popState()
+        GlStateManager.popMatrix()
     }
 
     companion object {


### PR DESCRIPTION
<!-- 
For japanese speakers:
PRのタイトルはChangelogに使われるので、なるべく英語にしてください。
PRの内容は日本語で大丈夫です。
-->
## What
- Refactor: removed memory/restore states from `CRenderUtils`. Now uses CCL's `GlStateTracker` instead. NOTE: some states including Texture2D is not tracked by CCL's one, so you have to track it manually.
- Reduced GL calls from CA Reactor rendering method.