### PR TITLE
fix: Storage Container not saving items on broke

### DIFF
--- a/src/main/kotlin/io/github/trcdevelopers/clayium/api/block/BlockMachine.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/api/block/BlockMachine.kt
@@ -157,7 +157,7 @@ class BlockMachine : Block(Material.IRON) {
         val stack = metaTileEntity.asStackForm()
         if (metaTileEntity is IHasItemStackNbt) {
             val data = NBTTagCompound()
-            metaTileEntity.writeToNBT(data)
+            metaTileEntity.writeItemStackNbt(data)
             if (!data.isEmpty) stack.tagCompound = data
         }
         drops.add(stack)


### PR DESCRIPTION
<!-- 
For japanese speakers:
PRのタイトルはChangelogに使われるので、なるべく英語にしてください。
PRの内容は日本語で大丈夫です。
-->
## What
Storage Containerが壊された時、中身を保持しないバグを修正

## Implementation Details
`BlockMachine`の`getDrops`にて、呼び出すメソッドが間違っていた
```kt
if (metaTileEntity is IHasItemStackNbt) {
    val data = NBTTagCompound()
    metaTileEntity.writeToNbt(data) // 本来はwriteItemStackNbt
    if (!data.isEmpty) stack.tagCompound = data
}
```

## Potential Compatibility Issues
なし