### PR TITLE
fix: Duping with storage container

### DIFF
--- a/src/main/kotlin/io/github/trcdevelopers/clayium/common/metatileentities/StorageContainerMetaTileEntity.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/common/metatileentities/StorageContainerMetaTileEntity.kt
@@ -424,8 +424,10 @@ class StorageContainerMetaTileEntity(
 
     private inner class StorageContainerExportItems : IItemHandlerModifiable {
         override fun setStackInSlot(slot: Int, stack: ItemStack) {
-            // this method should be called only for exporting item.
-            if (slot != 0 || stack.isItemEqual(currentInsertedStack)) return
+            if (slot != 0) return
+            // Changing the item is not allowed if there are still items stored
+            if (!stack.canActuallyStack(currentInsertedStack)) return
+
             val currentSlotAmount = min(itemsStored, 64)
             val amountAfterExtraction = stack.count
             val extractedAmount = currentSlotAmount - amountAfterExtraction


### PR DESCRIPTION
## What
Storage Containerの出力スロットを右クリックすることにより、アイテムが増殖するバグを修正

## Implementation Details
アイテムをGUIで右クリックした時、`StorageContainerExportItems`の`setStackInSlot`が呼ばれるが、最初のifでアイテムが同じ場合を弾いており、それ以降のアイテム数を減らす処理が行われていなかった。
おそらく異種のアイテムを弾く処理に`!`をつけ忘れたと思われるので、つけた。