### PR TITLE
fix: renovate is updating sakura mod to a newer MC ver

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -37,7 +37,7 @@
     {
       // renovate updates Sakura MOD to a different MC Version which breaks the build
       matchManagers: ["gradle"],
-      matchPackageNames: ["maven.modrinth:sakura_mod"],
+      matchPackageNames: ["maven.modrinth:sakura_mod", "maven.modrinth:mmlib"],
       enabled: false
     }
   ]

--- a/renovate.json5
+++ b/renovate.json5
@@ -33,6 +33,12 @@
       matchFileNames: ["**/mod_dependencies.gradle"],
       enabled: true,
       groupName: "Mod Dependencies",
+    },
+    {
+      // renovate updates Sakura MOD to a different MC Version which breaks the build
+      matchManagers: ["gradle"],
+      matchPackageNames: ["maven.modrinth:sakura_mod"],
+      enabled: false
     }
   ]
 }


### PR DESCRIPTION
## What
SSIA (e.g. `1.0.7-1.12.2 → 1.1.16-1.20.1`)

## Implementation Details
Add a rule to `renovate.json5`:
```json5
    {
      matchManagers: ["gradle"],
      matchPackageNames: ["maven.modrinth:sakura_mod"],
      enabled: false
    }
```