### PR TITLE
Update ModularUI

### DIFF
--- a/gradle/scripts/mod_dependencies.gradle
+++ b/gradle/scripts/mod_dependencies.gradle
@@ -39,7 +39,7 @@
 //file:noinspection DependencyNotationArgument
 
 dependencies {
-    api("com.cleanroommc:modularui:3.0.4") { transitive = false }
+    api("com.cleanroommc:modularui:3.1.1") { transitive = false }
     api("codechicken:codechickenlib:3.2.3.358")
     api("com.cleanroommc:groovyscript:1.3.1") { transitive = false }
 

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/api/metatileentity/MultiTrackBufferMetaTileEntity.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/api/metatileentity/MultiTrackBufferMetaTileEntity.kt
@@ -117,10 +117,8 @@ class MultiTrackBufferMetaTileEntity(
         (0..<trackRow).forEach { syncManager.registerSlotGroup("mt_buffer_inv_${it}", 1) }
         val slotsRowString = "I".repeat(trackInvSize)
         return ModularPanel("multi_track_buffer")
-            .flex {
-                it.size(max(GUI_DEFAULT_WIDTH, trackInvSize * 18 + 4 + 18 + /* margin*/ 12), 18 + trackRow * 18 + 94 + 2)
-                it.align(Alignment.Center)
-            }
+            .size(max(GUI_DEFAULT_WIDTH, trackInvSize * 18 + 4 + 18 + /* margin*/ 12), 18 + trackRow * 18 + 94 + 2)
+            .align(Alignment.Center)
             .columnWithPlayerInv {
                 child(buildMainParentWidget(syncManager)
                     .child(Column().width(trackInvSize * 18 + 4 + 18).height(trackRow * 18)

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/common/gui/sync/MerchantRecipeListSyncValue.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/common/gui/sync/MerchantRecipeListSyncValue.kt
@@ -37,6 +37,10 @@ class MerchantRecipeListSyncValue(
         return !isEqual
     }
 
+    override fun notifyUpdate() {
+        this.setValue(this.getter.get(), setSource = false, sync = true)
+    }
+
     override fun write(buffer: PacketBuffer) {
         this.cache!!.writeToBuf(buffer)
     }
@@ -47,5 +51,9 @@ class MerchantRecipeListSyncValue(
 
     override fun getValue(): MerchantRecipeList? {
         return this.cache
+    }
+
+    override fun getValueType(): Class<MerchantRecipeList> {
+        return MerchantRecipeList::class.java
     }
 }

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/common/gui/sync/MerchantRecipeListSyncValue.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/common/gui/sync/MerchantRecipeListSyncValue.kt
@@ -30,7 +30,9 @@ class MerchantRecipeListSyncValue(
         val value = this.getter.get()
         val valueNbt = value.map { it.writeToTags() }
         val cacheNbt = this.cacheNbt
-        val isEqual = cacheNbt != null && valueNbt.zip(cacheNbt).all { (t1, t2) -> t1 == t2 }
+        val isEqual = cacheNbt != null
+                && valueNbt.size == cacheNbt.size
+                && valueNbt.zip(cacheNbt).all { (t1, t2) -> t1 == t2 }
         if (isFirstSync || !isEqual) {
             setValue(value, setSource = false, sync = false)
         }


### PR DESCRIPTION
## What
Update ModularUI to 3.1.1

## Implementation Details
- Don't use `.flex` method in `MultiTrackBufferMetaTileEntity`
- `IValueSyncHandler` has 2 new methods, implement those in `MerchantRecipeListSyncValue`