### PR TITLE
refactor: The single arg ModularScreen constructor is deprecated

### DIFF
--- a/src/main/kotlin/io/github/trcdevelopers/clayium/integration/modularui/ModularScreenClayium.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/integration/modularui/ModularScreenClayium.kt
@@ -3,6 +3,7 @@ package io.github.trcdevelopers.clayium.integration.modularui
 import com.cleanroommc.modularui.integration.recipeviewer.RecipeViewerRecipeTransferHandler
 import com.cleanroommc.modularui.screen.ModularPanel
 import com.cleanroommc.modularui.screen.ModularScreen
+import io.github.trcdevelopers.clayium.api.MOD_ID
 import mezz.jei.api.gui.IRecipeLayout
 import mezz.jei.api.recipe.transfer.IRecipeTransferError
 import mezz.jei.transfer.RecipeTransferErrorTooltip
@@ -10,7 +11,7 @@ import mezz.jei.transfer.RecipeTransferErrorTooltip
 @Suppress("UnstableApiUsage")
 class ModularScreenClayium(
     panel: ModularPanel
-) : ModularScreen(panel), RecipeViewerRecipeTransferHandler {
+) : ModularScreen(MOD_ID, panel), RecipeViewerRecipeTransferHandler {
     init {
         this.useTheme(ModularUiInit.CLAYIUM_DEFAULT_THEME)
     }


### PR DESCRIPTION
単一引数の`ModularScreen`コンストラクターは非推奨になっているため、MOD IDも受け取るものを使う用に変更した。