### PR TITLE
Feature update modularui 3.1.6

### DIFF
--- a/gradle/scripts/mod_dependencies.gradle
+++ b/gradle/scripts/mod_dependencies.gradle
@@ -39,7 +39,7 @@
 //file:noinspection DependencyNotationArgument
 
 dependencies {
-    api("com.cleanroommc:modularui:3.1.5") { transitive = false }
+    api("com.cleanroommc:modularui:3.1.6") { transitive = false }
     api("codechicken:codechickenlib:3.2.3.358")
     api("com.cleanroommc:groovyscript:1.3.4") { transitive = false }
 

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/common/metatileentities/PanAdapterMetaTileEntity.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/common/metatileentities/PanAdapterMetaTileEntity.kt
@@ -182,7 +182,8 @@ class PanAdapterMetaTileEntity(
 
     override fun buildUI(data: MetaTileEntityGuiData, syncManager: PanelSyncManager): ModularPanel {
         val tabController = PagedWidget.Controller()
-        val buttons = Grid.createGridOfSizeWidth(resultInventories.size, 2) { _, _, index ->
+        val gridWidth = if (resultInventories.size == 1) 1 else 2
+        val buttons = Grid.createGridOfSizeWidth(resultInventories.size, gridWidth) { _, _, index ->
             val handler = resultInventories[index]
             ParentWidget().size(16)
                 .child(PageButton(index, tabController)

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/common/metatileentities/PanAdapterMetaTileEntity.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/common/metatileentities/PanAdapterMetaTileEntity.kt
@@ -5,14 +5,13 @@ import com.cleanroommc.modularui.drawable.DynamicDrawable
 import com.cleanroommc.modularui.drawable.GuiTextures
 import com.cleanroommc.modularui.drawable.ItemDrawable
 import com.cleanroommc.modularui.screen.ModularPanel
-import com.cleanroommc.modularui.utils.Alignment
 import com.cleanroommc.modularui.value.sync.PanelSyncManager
 import com.cleanroommc.modularui.widget.ParentWidget
 import com.cleanroommc.modularui.widgets.PageButton
 import com.cleanroommc.modularui.widgets.PagedWidget
 import com.cleanroommc.modularui.widgets.SlotGroupWidget
-import com.cleanroommc.modularui.widgets.layout.Grid
 import com.cleanroommc.modularui.widgets.layout.Flow
+import com.cleanroommc.modularui.widgets.layout.Grid
 import com.google.common.collect.ImmutableSet
 import io.github.trcdevelopers.clayium.api.ClayEnergy
 import io.github.trcdevelopers.clayium.api.ClayiumApi
@@ -183,7 +182,8 @@ class PanAdapterMetaTileEntity(
 
     override fun buildUI(data: MetaTileEntityGuiData, syncManager: PanelSyncManager): ModularPanel {
         val tabController = PagedWidget.Controller()
-        val buttons = Grid.mapToMatrix(2, resultInventories) { index, handler ->
+        val buttons = Grid.createGridOfSizeWidth(resultInventories.size, 2) { _, _, index ->
+            val handler = resultInventories[index]
             ParentWidget().size(16)
                 .child(PageButton(index, tabController)
                     .background(false, GuiTextures.MC_BUTTON)
@@ -207,7 +207,7 @@ class PanAdapterMetaTileEntity(
             Flow.row().widthRel(1f).height(64)
                 .child(Grid().width(32).heightRel(1f).left(0).top(0)
                     .minElementMargin(0, 0)
-                    .matrix(buttons)
+                    .grid(buttons)
                 )
                 .child(slots.left(32 + 8))
                 .child(resultSlots.right(0).top(0))

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/common/metatileentities/PanCoreMetaTileEntity.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/common/metatileentities/PanCoreMetaTileEntity.kt
@@ -235,7 +235,6 @@ class PanCoreMetaTileEntity(
         if (!isRemote) {
             refreshNetworkAndThenEntries()
         }
-//        val displayItems = Grid.mapToMatrix(9, duplicationEntries.toList()) { index, (itemAndMeta, entry) ->
         val duplicationEntriesList = duplicationEntries.toList()
         val displayItems = Grid.createGridOfSizeWidth(duplicationEntriesList.size, 9) { _, _, index ->
             val (itemAndMeta, entry) = duplicationEntriesList[index]

--- a/src/main/kotlin/io/github/trcdevelopers/clayium/common/metatileentities/PanCoreMetaTileEntity.kt
+++ b/src/main/kotlin/io/github/trcdevelopers/clayium/common/metatileentities/PanCoreMetaTileEntity.kt
@@ -4,7 +4,6 @@ import com.cleanroommc.modularui.api.drawable.IKey
 import com.cleanroommc.modularui.drawable.ItemDrawable
 import com.cleanroommc.modularui.drawable.Rectangle
 import com.cleanroommc.modularui.screen.ModularPanel
-import com.cleanroommc.modularui.utils.Alignment
 import com.cleanroommc.modularui.utils.Color
 import com.cleanroommc.modularui.value.sync.PanelSyncManager
 import com.cleanroommc.modularui.widget.ParentWidget
@@ -236,7 +235,10 @@ class PanCoreMetaTileEntity(
         if (!isRemote) {
             refreshNetworkAndThenEntries()
         }
-        val displayItems = Grid.mapToMatrix(9, duplicationEntries.toList()) { index, (itemAndMeta, entry) ->
+//        val displayItems = Grid.mapToMatrix(9, duplicationEntries.toList()) { index, (itemAndMeta, entry) ->
+        val duplicationEntriesList = duplicationEntries.toList()
+        val displayItems = Grid.createGridOfSizeWidth(duplicationEntriesList.size, 9) { _, _, index ->
+            val (itemAndMeta, entry) = duplicationEntriesList[index]
             val stack = itemAndMeta.asStack()
             ItemDrawable(stack).asWidget().size(16)
                 .tooltip { tooltip ->
@@ -267,7 +269,7 @@ class PanCoreMetaTileEntity(
                             .width(panDisplayWidth + panDisplayMargin * 2).heightRel(1f).margin(0, 9))
                         .child(Grid().width(panDisplayWidth).heightRel(1f).margin(panDisplayMargin, 13)
                             .minElementMargin(0, 0)
-                            .matrix(displayItems)
+                            .grid(displayItems)
                             .scrollable(VerticalScrollData())
                             .background(Rectangle().color(Color.rgb(0, 0x1E, 0))))
                     )


### PR DESCRIPTION
## What
* Update ModularUI to 3.1.6
* Replace deprecated functions with new one

## Implementation Details
* Panコア/複製機で使われていた、`mapToMatrix`, `matrix`というメソッドをそれぞれ`createGridOfSizeWidth`, `grid`に置き換えた

## Potential Compatibility Issues
全てのGUIをテストできたわけでないので、どれかが壊れている可能性